### PR TITLE
fix: shares.md "Primary Storage" title

### DIFF
--- a/docs/unraid-os/manual/shares.md
+++ b/docs/unraid-os/manual/shares.md
@@ -612,8 +612,9 @@ The shares that fall into this category are:
 The Unraid 6.12 release has introduced some new terminology to make it
 clearer to new users where files are initially placed and where they
 will end up. The same functionality is present in earlier releases, but
-has often been misunderstood by new users.\
-**Primary Storage:**
+has often been misunderstood by new users.
+
+#### **Primary Storage:**
 
 This is the location to which **new** files will be written.
 


### PR DESCRIPTION
The "Primary Storage" title was not a title and was rendered on the same line of the previous text block.

Before Submitting This PR, Please Ensure You Have Completed The Following:

1. [x] Are all new documentation files lowercase, with dash separated names (ex. unraid-os.mdx)?
2. [x] Are all assets (images, etc), located in an assets/ subfolder next to the .md/mdx files?
3. [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
4. [x] Is the build succeeding? (Not needed)
