### PR TITLE
Update manual-install-method.md

### DIFF
--- a/docs/unraid-os/getting-started/manual-install-method.md
+++ b/docs/unraid-os/getting-started/manual-install-method.md
@@ -6,22 +6,26 @@ sidebar_position: 3
 
 If for some reason the USB Flash Creator tool cannot be used, or your USB flash device is not detected, it is possible to manually format and prepare a bootable USB flash device.
 
-:::important
-
-This method only works for devices 32GB and smaller.
-
-:::
-
 1. Plug the USB flash device into your Mac or PC.
-2. Format the device using the FAT32 file system. It must **not** be ex-FAT or NTFS. If your drive is larger than 32GB then you need to use a 3rd party tool (e.g. Rufus) to format it to FAT32 as Windows will not give this as an option on drives larger than 32GB.
-3. Set the ‘volume label’ to `UNRAID` (case-sensitive, use all caps).
+2. If your device is 32GB or smaller then format the device using the FAT32 file system and set ‘volume label’ to `UNRAID` (case-sensitive, use all caps). It must **not** be ex-FAT or NTFS.
+   If your device is larger than 32GB then create a 32GB FAT32 partition and name it `UNRAID` (case-sensitive, use all caps)
+      On Windows:
+         2a. right click the start button and open `disk management`
+         2b. find your drive in the GUI on the lower half of the screen
+         2c. then delete any partitions currently on the drive by right clicking the blue bar and selecting `delete volume` (be really careful at this stage as a misclick could result in deleting the wrong drive easily) do this until the whole drive is `unallocated` with a black bar along the top
+         2d. then right click the black bar and select `new simple volume`
+         2e. on the popup window now select next to get past the introduction
+         2f. now for the `simple volume size in MB` enter `32000` and click next
+         2g. on the `assign drive letter or path` screen just let windows go with the letter it picks and select next
+         2h. on the `format partition` screen you want to ensure that `Format this volume with the following settings` is selected, the file system is 'FAT32' and the volume lable is `UNRAID` (case-sensitive, use all caps), then click next
+         2i. now click finish
 4. [Go to the downloads page.](http://lime-technology.com/download/) to get the zip file for the release you want to use.
 5. Choose a version and download it to a temporary location on your computer (e.g. a “downloads” folder).
 6. Extract the contents of the newly downloaded ZIP file onto your USB flash device.
 7. Browse to the USB flash device to see the newly extracted contents from your Mac or PC.
 8. If you need to enable UEFI boot, rename the `EFI-` directory to `EFI`.
 9. Run the _make bootable_ script appropriate to the OS you are using:
-    * **Windows XP** - double-click the **make_bootable** file.
+    * **Windows XP** - double-click the **make_bootable.bat** file.
     * **Windows 7 or later** - right-click the **make_bootable** file and select _Run as Administrator_.
     * **Mac** - double-click the file **make_bootable_mac** file and enter your admin password when prompted.
     * **Linux**:


### PR DESCRIPTION
added instructions for drives larger than 32GB and fixed instructions for windows xp's make bootable file as on win xp this would show up as make bootable.bat 

one thing to improve would be linux / mac instructions for larger drives but i dont know disk formatting in those OS's

Before Submitting This PR, Please Ensure You Have Completed The Following:

1. [ ] Are internal links to wiki documents using [relative file links](https://docusaurus.io/docs/markdown-features/links)? no new links
2. [ ] Are all new documentation files lowercase, with dash separated names (ex. unraid-os.mdx)? no new files
3. [ ] Are all assets (images, etc), located in an assets/ subfolder next to the .md/mdx files? no new assets
4. [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change? no open pull requests for this
5. [ ] Is the build succeeding? im not sure what this means, new to github so idk
