### PR TITLE
Fix broken links

### DIFF
--- a/docs/connect/remote-access.md
+++ b/docs/connect/remote-access.md
@@ -5,8 +5,7 @@
 The Remote Access feature
 allows you to access your Unraid WebGUI from the Internet. If you need
 access to Docker containers, network drives, or other devices on your
-network, you'll want to [setup a
-VPN](/unraid-os/manual/security/vpn.md) instead.
+network, you'll want to [setup a VPN](/unraid-os/manual/security/vpn.md) instead.
 
 **Note: Before enabling remote access, consider your root password. Is
 it sufficiently complex? Update your root password on the Users page.**
@@ -94,8 +93,8 @@ of the Dynamic settings in the Remote Access dropdown:
    Unraid Server is reachable from the Internet"
    - Note: When using Dynamic forwarding, you will not be able to
      access your server from this manual port forward unless you click
-     the Enable Dynamic Remote access button in [Unraid
-     Connect](/connect/help.md#unraid-connect-dashboard).
+     the Enable Dynamic Remote access button in
+     [Unraid Connect](/connect/help.md#unraid-connect-dashboard).
 5. Note: If the setting changes from UPnP to "Manual Port Forward" when
    you reload the page, then we were not able to communicate with your
    router to enable UPnP. It may need to be enabled on your router, or
@@ -118,21 +117,19 @@ of the Dynamic settings in the Remote Access dropdown:
    Unraid Server is reachable from the Internet"
    - Note: When using Dynamic forwarding, you will not be able to
      access your server from this manual port forward unless you click
-     the Enable Dynamic Remote access button in [Unraid
-     Connect](/connect/help.md#unraid-connect-dashboard)
-5. To access your server using Remote Access, login to [Unraid
-   Connect](/connect/help.md#unraid-connect-dashboard) and click the Manage link
+     the Enable Dynamic Remote access button in
+     [Unraid Connect](/connect/help.md#unraid-connect-dashboard)
+5. To access your server using Remote Access, login to
+   [Unraid Connect](/connect/help.md#unraid-connect-dashboard) and click the Manage link
 
 ===Optional step for secure local access=== If you want to use secure
-https for local access to your server as well, navigate to Settings → 
+https for local access to your server as well, navigate to Settings →
 Management Access. In the CA-signed certificate area, if there are no
 warnings about DNS Rebinding then go ahead and set **Use SSL/TLS** to
-**Strict**. If there are warnings about DNS Rebinding see [A note
-regarding DNS Rebinding
-Protection](/connect/help.md#a-note-regarding-dns-rebinding-protection).
+**Strict**. If there are warnings about DNS Rebinding see 
+[A note regarding DNS Rebinding Protection](/connect/help.md#a-note-regarding-dns-rebinding-protection).
 
 Note that once SSL is set to Strict, your client computers will need
 access to DNS in order to access your server. This means if your
 Internet connection drops you will likely lose access to your server's
-WebGUI. See [How to access your server when DNS is
-down](/connect/help.md#how-to-access-your-server-when-dns-is-down).
+WebGUI. See [How to access your server when DNS is down](/connect/help.md#how-to-access-your-server-when-dns-is-down).

--- a/docs/legacy/Articles/expanding-windows-vm-vdisk-partitions.md
+++ b/docs/legacy/Articles/expanding-windows-vm-vdisk-partitions.md
@@ -2,8 +2,7 @@
 
 ## Overview
 
-If you've followed the steps outlined in [this
-article](/unraid-os/manual/vm/vm-management.md#expanding-a-vdisk) to expand a
+If you've followed the steps outlined in [this article](/unraid-os/manual/vm/vm-management.md#expanding-a-vdisk) to expand a
 vdisk for your Windows installation, this article will teach you how to
 expand your partition in Windows so you can take advantage of that extra
 space. Windows has this pesky habit of adding a recovery partition to
@@ -17,8 +16,8 @@ to extend the C:\\ partition.
 
 ![](../assets/Resize_vdisk_2_(using_diskpart_to_delete_recovery_partition).PNG)
 
-Perform the following steps _after_ completing the steps in [this
-article](/unraid-os/manual/vm/vm-management.md#expanding-a-vdisk) to expand
+Perform the following steps _after_ completing the steps in
+[this article](/unraid-os/manual/vm/vm-management.md#expanding-a-vdisk) to expand
 the vdisk itself:
 
 - Start your Windows VM.

--- a/docs/legacy/FAQ/check-disk-filesystems.md
+++ b/docs/legacy/FAQ/check-disk-filesystems.md
@@ -22,7 +22,7 @@
     [Need help? Read me
     first!](https://forums.unraid.net/forum/index.php?topic=39257).
   - If hardware or drive issues please see the
-    [Troubleshooting](/unraid-os/manual/troubleshooting)
+    [Troubleshooting](/unraid-os/troubleshooting/troubleshooting.md)
     page.
 
 - **Very important!!! Do NOT run these tools
@@ -106,8 +106,7 @@
 
 - If you are running Unraid v6, you can use the WebGUI to check and
   fix the file system of any data drive. Unless you prefer to work at
-  the command line, go to [Checking and fixing drives in the
-  WebGUI](#checking-and-fixing-drives-in-the-WebGUI).
+  the command line, go to [Checking and fixing drives in the WebGUI](#checking-and-fixing-drives-in-the-webgui).
 
 - If you are running Unraid v4 or v5 or prefer working at the command
   line -
@@ -329,8 +328,7 @@ file system of a data drive, while maintaining its parity info.
 ### Running xfs_repair
 
 - Now you are ready to run the XFS file system test. At the console or
-  in a [terminal session with SSH or
-  Telnet](terminal-access.md), type this: (_Note: the
+  in a [terminal session with SSH or Telnet](terminal-access.md), type this: (_Note: the
   following example refers to Disk 1, as **/dev/md1**. You will need
   to substitute the correct drive for your case. For example, if it is
   your Disk 5 that you are testing, then substitute **md5** for
@@ -432,7 +430,7 @@ xfs_repair -v /dev/md1
 - We're sorry, but we don't have enough experience yet with the
   **scrub** command. We recommend reading through this section, then
   either using the
-  [WebGUI](#checking-and-fixing-drives-in-the-WebGUI)
+  [WebGUI](#checking-and-fixing-drives-in-the-webgui)
   to possibly repair a drive formatted with **BTRFS**, or if you are
   comfortable at the command line, checking out the **scrub** command
   and its options, see [btrfs
@@ -549,8 +547,7 @@ xfs_repair -v /dev/md1
 
 - Now you are ready to run the Reiser file system test. (Note:
   \--check is the default option, not strictly required, but included
-  here for clarification.) At the console or in a [terminal session
-  with SSH or Telnet](terminal-access.md), type this:
+  here for clarification.) At the console or in a [terminal session with SSH or Telnet](terminal-access.md), type this:
 
   ```shell
   reiserfsck --check /dev/md1 [answer with the word **Yes**
@@ -669,8 +666,7 @@ xfs_repair -v /dev/md1
 
 ### Preparing to run reiserfsck
 
-- Start the array, then from the console or in a [terminal session
-  with SSH or Telnet](terminal-access.md), type this:
+- Start the array, then from the console or in a [terminal session with SSH or Telnet](terminal-access.md), type this:
 
 ```shell
     cd [this will make sure you are in the /root directory]
@@ -690,8 +686,7 @@ xfs_repair -v /dev/md1
 
 - Now you are ready to run the Reiser file system test. (Note:
   \--check is the default option, not strictly required, but included
-  here for clarification.) At the console or in a [terminal session
-  with SSH or Telnet](terminal-access.md), type this:
+  here for clarification.) At the console or in a [terminal session with SSH or Telnet](terminal-access.md), type this:
 
 ```shell
     reiserfsck --check /dev/md1

--- a/docs/legacy/FAQ/console.md
+++ b/docs/legacy/FAQ/console.md
@@ -7,8 +7,7 @@ if you can!**
 
 ## Basics of Console Usage
 
-- If you are new to Linux, start by reading the [Terminal
-  Access](terminal-access.md) page.
+- If you are new to Linux, start by reading the [Terminal Access](terminal-access.md) page.
 - The commands below usually list a usage note, which is a link to a
   'man page'. In Linux, man pages describe the syntax of command
   usage, including all options for the command. Linux splits all of
@@ -102,8 +101,8 @@ console or terminal prompt)
 To determine the read speed of a hard drive, the following command can
 be used. The very last number in MB/sec is the one you want, ignore the
 rest. Although one run will give you a decent result, for better
-accuracy, take the average of at least 5 runs. See also [Check Harddrive
-Speed](check-harddrive-speed.md).
+accuracy, take the average of at least 5 runs. See also 
+[Check Harddrive Speed](check-harddrive-speed.md).
 
 `hdparm  -tT  /dev/sdx`
 
@@ -116,7 +115,7 @@ To obtain the SMART info for a drive, including some identity and
 configuration information, and physical statistics and error history.
 For more information about SMART and `smartctl`, see
 [here](https://forums.unraid.net/forum/index.php?topic=1521) and
-[here](/unraid-os/manual/troubleshooting#data-recovery) and
+[here](/unraid-os/troubleshooting/data-recovery.md) and
 [here](https://forums.unraid.net/forum/index.php?topic=1845.msg13042#msg13042)
 and [here](https://forums.unraid.net/forum/index.php?topic=2097) and
 [here](https://forums.unraid.net/forum/index.php?topic=2074.0).
@@ -345,8 +344,8 @@ or you can individually terminate individual process IDs by typing
 
 ## Console Commands for Files and Folders
 
-Many more file and folder commands can be found in the [Basics of
-Console Usage](#basics-of-bonsole-usage) section
+Many more file and folder commands can be found in the
+[Basics of Console Usage](#basics-of-console-usage) section
 above.
 
 - `df` - [usage](http://linux.die.net/man/1/df)
@@ -364,8 +363,8 @@ above.
 ## Console Commands for System Information
 
 In the commands below, `cat` is often used to display info, but
-`more` and `less` can be used instead (see [Basics of Console
-Usage](#basics-of-bonsole-usage) section above).
+`more` and `less` can be used instead (see
+[Basics of Console Usage](#basics-of-console-usage) section above).
 
 ### CPU Info
 

--- a/docs/legacy/FAQ/replacing-a-data-drive.md
+++ b/docs/legacy/FAQ/replacing-a-data-drive.md
@@ -28,8 +28,7 @@ would you want to do that? Any number of reasons...
 
 - **Important! You cannot replace a drive with one that is LARGER than
   the parity drive!** If your replacement drive is larger than the
-  parity drive, then proceed to [The parity swap
-  procedure](parity-swap-procedure.md).
+  parity drive, then proceed to [The parity swap procedure](parity-swap-procedure.md).
 
 - Unraid does not require the replacement drive to be the same size as
   the old drive being replaced. It CANNOT be smaller, but it CAN be a
@@ -44,8 +43,8 @@ would you want to do that? Any number of reasons...
   the Unraid forums), and are SURE that the drive is good, then you
   can use the procedures below to rebuild it onto itself (below,
   consider the 'old drive' to be the 'new drive'). There is a
-  similar procedure just for this though → [Re-enable the
-  drive](/unraid-os/manual/storage-management.md#rebuilding-a-drive-onto-itself).
+  similar procedure just for this though →
+  [Re-enable the drive](/unraid-os/manual/storage-management.md#rebuilding-a-drive-onto-itself).
 
 ## The procedure
 

--- a/docs/legacy/FAQ/terminal-access.md
+++ b/docs/legacy/FAQ/terminal-access.md
@@ -100,9 +100,8 @@ mentioned, such as anywhere in the Wiki or the Unraid forums. It is
 used the same way as Windows Telnet, but because it supports the
 mouse and arrow and function keys, it is much easier to use in
 programs like MC (Midnight Commander, a dual pane commander-like
-file manager). For an example, see [Transferring Files Within the
-Unraid
-Server](transferring-files-within-the-unraid-server.md).
+file manager). For an example, see
+[Transferring Files Within the Unraid Server](transferring-files-within-the-unraid-server.md).
 
 _Note for UnRAID v5 and v6 users: some have found that Midnight
 Commander looks funny, with accented letters (mostly a little 'a'
@@ -111,8 +110,7 @@ configuration, go to Window → Translation and set Remote Character
 Set to something like UTF-8, then restart MC (thanks to Wody for
 this tip, see
 [this](https://forums.unraid.net/forum/index.php?topic=18157)).
-Wody has an additional PuTTY tip in [this
-post](https://forums.unraid.net/forum/index.php?topic=18157.msg162943#msg162943)._
+Wody has an additional PuTTY tip in [this post](https://forums.unraid.net/forum/index.php?topic=18157.msg162943#msg162943)._
 
 PuTTY has a number of settings, but the defaults are usually fine.
 On the **Window** tab, I set **Columns** to 120, **Rows** to 60, and
@@ -171,11 +169,9 @@ right-clicking the title bar. Notes regarding the command shell:
 
 ## Related links
 
-- [SSH vs
-  Telnet](https://forums.unraid.net/forum/index.php?topic=30273) -
+- [SSH vs Telnet](https://forums.unraid.net/forum/index.php?topic=30273) -
   discussion of the merits of both, why many want Telnet disabled
-- [Google search of "how to secure your ssh
-  server"](http://www.google.com/search?q=how+to+secure+your+ssh+server)
+- [Google search of "how to secure your ssh server"](http://www.google.com/search?q=how+to+secure+your+ssh+server)
 - [Console](console.md) - basics of console usage, plus
   commands for drives, networking, system management, files and
   folders, and system information

--- a/docs/legacy/FAQ/transferring-files-within-the-unraid-server.md
+++ b/docs/legacy/FAQ/transferring-files-within-the-unraid-server.md
@@ -17,7 +17,7 @@ Midnight Commander is a Linux console tool, and needs to be run from
 either the physical console on your Unraid server, or from a Telnet
 console on your desktop station. For more information, see the
 [Telnet](terminal-access.md#telnet) page, which includes information on
-[PuTTY](terminal-access.md#PuTTY).
+[PuTTY](terminal-access.md#putty).
 
 ## Move Files Overnight
 

--- a/docs/legacy/FAQ/understanding-smart-reports.md
+++ b/docs/legacy/FAQ/understanding-smart-reports.md
@@ -456,7 +456,7 @@ incomplete!]_
     very large numbers they find in a SMART report or 'diff'
   - https://forums.unraid.net/forum/index.php?topic=2135.msg15733#msg15733 -
     a script for grabbing dated SMART reports for all drives
-  - [Data Recovery](/unraid-os/manual/troubleshooting#data-recovery)
+  - [Data Recovery](/unraid-os/troubleshooting/data-recovery)
   - https://forums.unraid.net/forum/index.php?topic=2708 - the
     MyMain thread; an UnMENU plugin; after installing UnMENU,
     install this next; has a Smart View that provides color-coded

--- a/docs/unraid-os/faq/licensing-faq.md
+++ b/docs/unraid-os/faq/licensing-faq.md
@@ -91,8 +91,7 @@ No problem—just pay the extension fee and jump back in (subject to the current
 
 Unraid Pro, Unleashed and Lifetime licenses support up to 30 storage devices in the parity-protected
 array (28 data and 2 parity) and up to 35 named pools, of up to 30
-storage devices in the [cache
-pool(s)](/unraid-os/release-notes/6.9.0.md#multiple-pools).
+storage devices in the [cache pool(s)](/unraid-os/release-notes/6.9.0.md#multiple-pools).
 Additional storage devices can still be utilized directly with other
 Unraid features such as [Virtual Machines](../manual/vm/vm-management.md) or the unassigned devices
 plugin.

--- a/docs/unraid-os/faq/os-faq.md
+++ b/docs/unraid-os/faq/os-faq.md
@@ -39,7 +39,7 @@ Support)](https://forums.unraid.net/forum/55-general-support/).
 
 ## What Should I do if I have Forgotten my Root Password?
 
-See [Lost Root Password](/unraid-os/manual/troubleshooting/#lost-root-password)
+See [Resetting your Unraid password](/unraid-os/manual/users/reset-password.md)
 
 _Important: this process only works for user passwords. If you encrypt your drives and forget this password, unfortunately you are hosed. There is no way for Lime Technology or anyone to recover this password. Please remember it or write it down in a secure, locked place!_
 

--- a/docs/unraid-os/manual/changing-the-flash-device.md
+++ b/docs/unraid-os/manual/changing-the-flash-device.md
@@ -65,7 +65,7 @@ To back up your Flash drive in Unraid:
 2. Under **Flash Device Settings**, select the **FLASH BACKUP** button to download a fully zipped backup of your current flash drive to your Mac or PC.
 ![Flash backup](../assets/Backup_flash_drive.png)
 
-Alternatively, you can use [Unraid Connect](../../connect/help.md#restoring-flash-backup) to back up your Flash boot device.
+Alternatively, you can use [Unraid Connect](../../connect/help.md#restoring-a-flash-backup) to back up your Flash boot device.
 
 #### What if I can't backup my device?
 

--- a/docs/unraid-os/manual/shares/disk-shares.md
+++ b/docs/unraid-os/manual/shares/disk-shares.md
@@ -37,4 +37,5 @@ You must ***never*** copy between a user share and a disk share in the same copy
 
 At the base system level, Linux does not understand user shares, and cannot tell apart a file in a disk share from one in a user share. If you mix the share types in the same copy command you can end up trying to copy the file to itself which results in the file being truncated to zero length and its content being lost.
 
-There is no problem if the copy is between shares of the same type, or copying to/from a disk mounted as an [Unassigned Disk](../storage-management.md#unassigned-drives).
+There is no problem if the copy is between shares of the same type, or copying to/from a disk mounted as an
+[Unassigned Disk](../storage-management.md#unassigned-drives).

--- a/docs/unraid-os/manual/upgrade-instructions.md
+++ b/docs/unraid-os/manual/upgrade-instructions.md
@@ -8,7 +8,7 @@ Before upgrading, we highly recommend making a complete backup of your USB flash
 2. Under **Flash Device Settings**, select the **Flash Backup** button to download a fully zipped backup of your current flash drive to your Mac or PC.
 ![Flash backup](../assets/Backup_flash_drive.png)
 
-Alternatively, if you want, you can use [Unraid Connect](../../connect/help.md#restoring-flash-backup) to back up your Flash boot device.
+Alternatively, if you want, you can use [Unraid Connect](../../connect/help.md#restoring-a-flash-backup) to back up your Flash boot device.
 
 ## Upgrading from version 6.4 or higher
 

--- a/docs/unraid-os/manual/vm/vm-support.md
+++ b/docs/unraid-os/manual/vm/vm-support.md
@@ -195,7 +195,7 @@ Microsoft's website suggests that if you want to upgrade to Windows 10, use the 
 
 #### Upgrade VirtIO Drivers to 0.1.109 or later
 
-If you used the 0.1.102 drivers for your Windows 7 or 8.1 VM, you will want to upgrade these drivers to 0.1.109 or later before performing the upgrade. The process to update the drivers is located [here](#updating-virtio-drivers):
+If you used the 0.1.102 drivers for your Windows 7 or 8.1 VM, you will want to upgrade these drivers to 0.1.109 or later before performing the upgrade. The process to update the drivers is located [here](#using-virtio-drivers):
 
 #### Obtaining the Installation Media
 

--- a/docs/unraid-os/overview/ui-reference.md
+++ b/docs/unraid-os/overview/ui-reference.md
@@ -75,7 +75,7 @@ The **Docker** screen displays  all the containers you have installed from Commu
 
 :::note
 
-If your Unraid server meets the [hardware virtualization requirements](../manual/vm/vm-management/#determining-hvmiommu-hardware-support), this option displays in the navigation bar. Otherwise, this option will not be visible.
+If your Unraid server meets the [hardware virtualization requirements](../manual/vm/vm-management.md#determining-hvmiommu-hardware-support), this option displays in the navigation bar. Otherwise, this option will not be visible.
 
 :::
 
@@ -85,7 +85,8 @@ The **VMs** screen lets you manage VMs on your Unraid server. Any VMs you have c
 
 The **Apps** screen, otherwise known as the Community Applications, is the official source for Unraid applications.
 
-As the name implies, Community Applications provides community-sourced applications in the form of plugins and docker containers, that extend Unraid functionality beyond that of a mere NAS. You can read more about this in the [Community Applications section](../manual/applications.md#community-applications).
+As the name implies, Community Applications provides community-sourced applications in the form of plugins and docker containers, that extend Unraid functionality beyond that of a mere NAS. You can read more about this in the
+[Community Applications section](../manual/applications.md).
 
 ### Tools
 

--- a/docs/unraid-os/release-notes/6.12.8.md
+++ b/docs/unraid-os/release-notes/6.12.8.md
@@ -29,7 +29,7 @@ that Unraid has shipped with since version 6.11.5 and should work for most syste
 
 Note that some users have reported issues with port forwarding from certain routers (Fritzbox) and reduced
 functionality with advanced network management tools (Ubiquity) when in ipvlan mode. If this affects you,
-see the alternate solution available since Unraid [6.12.4](6.12.4.mc#fix-for-macvlan-call-traces).
+see the alternate solution available since Unraid [6.12.4](6.12.4.md#fix-for-macvlan-call-traces).
 
 #### Network problems due to jumbo frames
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -256,20 +256,29 @@ const config = {
             to: "/account/",
             from: "/unraid-os/faq/unraid-account/",
           },
-          // move User and Overview pages
-          // User and Overview sections redirects
-          {
-            to: "/unraid-os/manual/users/reset-password/",
-            from: "/unraid-os/manual/troubleshooting/",
-          },
+          // Overview redirect
           {
             to: "/unraid-os/overview/what-is-unraid/",
             from: "/unraid-os/manual/what-is-unraid/",
           },
-          //Troubleshooting section redirect
+          // Troubleshooting section redirect
+          // skip, lost-root-password takes precedence
+          /*
           {
             to: "/unraid-os/troubleshooting/",
             from: "/unraid-os/manual/troubleshooting/",
+          },
+          */
+          // reset password redirect
+          {
+            to: "/unraid-os/manual/users/reset-password/",
+            from: "/unraid-os/manual/troubleshooting/",
+            // actually from: /unraid-os/manual/troubleshooting#lost-root-password
+          },
+          // VM reorg
+          {
+            to: "/unraid-os/manual/vm/vm-management/",
+            from: "/unraid-os/manual/vm-management/",
           },
         ],
       },


### PR DESCRIPTION
For relative links to work, Docusaurus requires the full `[text](url)` to be on a single line. Any line breaks in the `[text]` area will break the link.

Also, anchor tags must be written in lower case.

Before Submitting This PR, Please Ensure You Have Completed The Following:

1. [x] Are internal links to wiki documents using [relative file links](https://docusaurus.io/docs/markdown-features/links)?
2. [x] Are all new documentation files lowercase, with dash separated names (ex. unraid-os.mdx)?
3. [x] Are all assets (images, etc), located in an assets/ subfolder next to the .md/mdx files?
4. [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
5. [x] Is the build succeeding?
