### PR TITLE
Update storage-management.md

### DIFF
--- a/docs/unraid-os/manual/storage-management.md
+++ b/docs/unraid-os/manual/storage-management.md
@@ -1480,7 +1480,7 @@ the pool from the RAID1 to the SINGLE profile.
 To replace a disk in the redundant pool, perform the following steps:
 
 1. Stop the array.
-2. Physically detach the disk from your system you wish to remove.
+2. (optional) Physically detach the disk from your system you wish to remove.
 3. Attach the replacement disk (must be equal to or larger than the
    disk being replaced).
 4. Refresh the Unraid WebGUI when under the **Main** tab.


### PR DESCRIPTION
In `Replace a disk in a pool` section, add `optional` to physically remove the disk from server

I don't think this is required. (right?)

In replace a disk from array section, it also only specified that disk-to-be-replaced should be unassigned, and did not require it to be physically removed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Enhanced clarity and detail in the storage management manual for Unraid.
	- Added optional steps for disk detachment and clarified conditions for adding disks.
	- Expanded instructions on managing cache pools, detailing single vs. multi-device modes.
	- Improved guidance on selecting, creating, and changing file systems with a focus on data preservation.
	- Included comprehensive explanations of BTRFS operations, emphasizing balance and scrub operations.
	- Adjusted overall structure for improved readability and usability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->