### PR TITLE
[tailscale] Extend description of Certificate Transparency

### DIFF
--- a/docs/unraid-os/manual/security/tailscale.md
+++ b/docs/unraid-os/manual/security/tailscale.md
@@ -22,7 +22,7 @@ On the [Tailscale website](https://login.tailscale.com/admin/dns), navigate to t
 
 :::warning
 
-Keep in mind that HTTPS Certificates are public, so make sure you are comfortable with your machine names being public before you do this.
+Keep in mind that [details about issued HTTPS certificates are public](https://certificate.transparency.dev/howctworks/), even if you only use them on a private network, so make sure you are comfortable with your machine names being public before you do this.
 
 :::
 


### PR DESCRIPTION
Make it clearer why certificate details are public.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated Tailscale documentation with a more detailed warning about HTTPS certificate transparency
  - Added external link explaining how certificate details are publicly accessible

<!-- end of auto-generated comment: release notes by coderabbit.ai -->