### PR TITLE
Update licensing-faq.md

### DIFF
--- a/docs/unraid-os/faq/licensing-faq.md
+++ b/docs/unraid-os/faq/licensing-faq.md
@@ -90,7 +90,7 @@ No problem—just pay the extension fee and jump back in (subject to the current
 ## What does "Unlimited" mean for attached storage devices?
 
 Unraid Pro, Unleashed and Lifetime licenses support up to 30 storage devices in the parity-protected
-array (28 data and 2 parity) and up to 35 named pools, of up to 30
+array (28 data and 2 parity) and up to 35 named pools, of up to 60
 storage devices in the [cache pool(s)](/unraid-os/release-notes/6.9.0.md#multiple-pools).
 Additional storage devices can still be utilized directly with other
 Unraid features such as [Virtual Machines](../manual/vm/vm-management.md) or the unassigned devices


### PR DESCRIPTION
Pools currently support up to 60 devices

Before Submitting This PR, Please Ensure You Have Completed The Following:

1. [ ] Are internal links to wiki documents using [relative file links](https://docusaurus.io/docs/markdown-features/links)?
2. [ ] Are all new documentation files lowercase, with dash separated names (ex. unraid-os.mdx)?
3. [ ] Are all assets (images, etc), located in an assets/ subfolder next to the .md/mdx files?
4. [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
5. [ ] Is the build succeeding?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated Unraid licensing FAQ to clarify storage device support
	- Specified that Pro, Unleashed, and Lifetime licenses now support up to 60 storage devices in cache pool(s)
	- Improved text formatting for better readability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->