### PR TITLE
Add go link for tailscale-docker

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -532,6 +532,10 @@ const config = {
             to: "/unraid-os/manual/security/tailscale/",
             from: "/go/tailscale",
           },
+          {
+            to: "/unraid-os/manual/security/tailscale/#adding-tailscale-to-docker-containers",
+            from: "/go/tailscale-docker",
+          },
         ],
       },
     ],


### PR DESCRIPTION
Before Submitting This PR, Please Ensure You Have Completed The Following:

1. [ ] Are internal links to wiki documents using [relative file links](https://docusaurus.io/docs/markdown-features/links)?
2. [ ] Are all new documentation files lowercase, with dash separated names (ex. unraid-os.mdx)?
3. [ ] Are all assets (images, etc), located in an assets/ subfolder next to the .md/mdx files?
4. [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
5. [ ] Is the build succeeding?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Added a redirect from `/go/tailscale-docker` to the updated Tailscale Docker containers documentation section
	- Ensures users accessing the old URL are seamlessly guided to the new documentation location

<!-- end of auto-generated comment: release notes by coderabbit.ai -->