### PR TITLE
Update storage-management.md

### DIFF
--- a/docs/unraid-os/manual/storage-management.md
+++ b/docs/unraid-os/manual/storage-management.md
@@ -1487,8 +1487,7 @@ To replace a disk in the redundant pool, perform the following steps:
 5. Select the pool slot that previously was set to the old disk and
    assign the new disk to the slot.
 6. Start the array.
-7. If presented with an option to **Format** the device, click the
-   checkbox and button to do so.
+7. Device replacement will start automatically.
 
 ## Remove a disk from a pool
 


### PR DESCRIPTION
User should never format a pool during a replacement

Before Submitting This PR, Please Ensure You Have Completed The Following:

1. [ ] Are internal links to wiki documents using [relative file links](https://docusaurus.io/docs/markdown-features/links)?
2. [ ] Are all new documentation files lowercase, with dash separated names (ex. unraid-os.mdx)?
3. [ ] Are all assets (images, etc), located in an assets/ subfolder next to the .md/mdx files?
4. [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
5. [ ] Is the build succeeding?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated disk replacement instructions in the storage management guide to automatically initiate the replacement process, removing the need for manual formatting. This streamlines the procedure and simplifies the overall user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->