### PR TITLE
Add 7.0.0-beta.4

### DIFF
--- a/docs/unraid-os/release-notes/7.1.0.md
+++ b/docs/unraid-os/release-notes/7.1.0.md
@@ -1,4 +1,4 @@
-# Version 7.1.0-beta.3 2025-04-04
+# Version 7.1.0-beta.4 2025-04-08
 
 **This is BETA software. Please use on test servers only.**
 
@@ -24,6 +24,8 @@ We are actively working to prevent this issue. If you continue to see this in th
 
 ### Rolling back
 
+We are making improvements to how we distribute patches between releases, so the standalone Patch Plugin will be uninstalled from this release. If rolling back to an earlier release we'd recommend reinstalling it. More details to come.
+
 If rolling back earlier than 7.0.0, also see the [7.0.0 release notes](7.0.0.md#rolling-back).
 
 ## Changes vs. [7.0.1](7.0.1.md)
@@ -45,6 +47,7 @@ If rolling back earlier than 7.0.0, also see the [7.0.0 release notes](7.0.0.md#
 * mover:
   * Fix: Resolved issue with older share.cfg files that prevented mover from running. [-beta.2]
   * Fix: mover would fail to recreate hard link if parent directory did not already exist. [-beta.2]
+  * Fix: mover hanging on named pipes [-beta.4]
 
 ## Networking
 
@@ -65,7 +68,8 @@ Additional details
 
 * WPA2/WPA3 and WPA2/WPA3 Enterprise are supported
 * Having both wired and wireless isn't recommended for long term use, it should be one or the other. But if both connections use DHCP and you (un)plug a network cable while wireless is configured, the system (excluding Docker) should adjust within 45-60 seconds.
-* Wireless chipset support: if your WiFi adapter can't connect to the network, please start a new forum thread and provide your diagnostics. We expect to have success with modern WiFi adapters, but older adapters may not work.
+* Wireless chipset support: We expect to have success with modern WiFi adapters, but older adapters may not work. If your WiFi adapter isn't detected, please start a new forum thread and provide your diagnostics so it can be investigated.
+* Firmware files placed in `/boot/config/firmware/` will be copied to `/lib/firmware/` before driver modules are loaded [-beta.4]
 * Fix: Encrypted WiFi password removed from diagnostics [-beta.2]
 * Fix: Prevent SSIDs from being listed twice, and suppress SSID named `\x00\x00\x00\x00\x00` [-beta.2]
 * Fix: Enabled the Apply button when adding a VLAN [-beta.3]
@@ -93,6 +97,8 @@ Limitations: there are networking limitations when using wireless, as a wlan can
 * When configuring multiple network interfaces, by default the additional interfaces will have their gateway disabled, this is a safe default that works on most networks where a single gateway is required. If an additional gateway is enabled, it will be given a higher metric than existing gateways so there are no conflicts. You can override as needed.
 * Old network interfaces are automatically removed from config files when you save changes to ***Settings → Network Settings***
 * Fix various issued with DHCP
+* Fix: resolved issue warning about duplicate default gateway metrics when using VLANs [-beta.4]
+* Fix: revert to previous behavior of not showing the DHCP recommended domain name [-beta.4]
 
 ## VM Manager
 
@@ -134,6 +140,7 @@ Import/Export
 ### Other VM changes
 
 * When the **Primary** GPU is assigned as passthrough for a VM, warn that it won't work without loading a compatible vBIOS.
+* Fix: resolved issue stopping the Array due to VMs not stopping first [-beta.4]
 
 ## WebGUI
 
@@ -150,6 +157,7 @@ To change this behavior, navigate to ***Settings → Display Settings*** and mod
 ### Other WebGUI changes
 
 * Automatically restart nginx if nchan runs out of shared_memory [-beta.3]
+* Fix: AdBlockers could prevent dashboard from loading [-beta.4]
 
 ## Misc
 
@@ -165,7 +173,7 @@ To change this behavior, navigate to ***Settings → Display Settings*** and mod
 
 ### Linux kernel
 
-* version 6.12.21
+* version 6.12.22
   * CONFIG_NR_CPUS: increased from 256 to 512
   * CONFIG_TEHUTI_TN40: Tehuti Networks TN40xx 10G Ethernet adapters
   * CONFIG_DRM_XE: Intel Xe Graphics
@@ -200,23 +208,23 @@ To change this behavior, navigate to ***Settings → Display Settings*** and mod
 * docker: version 27.5.1
 * e2fsprogs: version 1.47.2
 * elogind: version 255.17
-* ethtool: version 6.11
+* ethtool: version 6.14
 * floppy: version 5.6
 * gdbm: version 1.25
 * git: version 2.49.0
-* glib2: version 2.84.0
+* glib2: version 2.84.1
 * glibc: version 2.41
 * glibc-zoneinfo: version 2025b
 * gtk+3: version 3.24.49
-* harfbuzz: version 11.0.0
+* harfbuzz: version 11.0.1
 * htop: version 3.4.0
 * icu4c: version 77.1
-* inih: version 59
+* inih: version 60
 * intel-microcode: version 20250211
 * iproute2: version 6.14.0
 * iw: version 6.9
 * jansson: version 2.14.1
-* kernel-firmware: version 20250328_4bfa7c6
+* kernel-firmware: version 20250401_d864697
 * kmod: version 34.2
 * less: version 674
 * libSM: version 1.2.6
@@ -228,6 +236,7 @@ To change this behavior, navigate to ***Settings → Display Settings*** and mod
 * libffi: version 3.4.7
 * libidn: version 1.43
 * libnvme: version 1.12
+* libgpg-error: version 1.52
 * libpng: version 1.6.47
 * libseccomp: version 2.6.0
 * liburing: version 2.9
@@ -245,7 +254,8 @@ To change this behavior, navigate to ***Settings → Display Settings*** and mod
 * mcelog: version 204
 * mesa: version 25.0.2
 * mpfr: version 4.2.2
-* ncurses: version 6.5_20250315
+* nano: version 8.4
+* ncurses: version 6.5_20250405
 * nettle: version 3.10.1
 * nghttp2: version 1.65.0
 * nghttp3: version 1.8.0
@@ -287,7 +297,7 @@ To change this behavior, navigate to ***Settings → Display Settings*** and mod
 * xorg-server: version 21.1.16
 * xterm: version 397
 * xtrans: version 1.6.0
-* xz: version 5.8.0
+* xz: version 5.8.1
 * zstd: version 1.5.7
 
 ## Patches


### PR DESCRIPTION
Before Submitting This PR, Please Ensure You Have Completed The Following:

1. [ ] Are internal links to wiki documents using [relative file links](https://docusaurus.io/docs/markdown-features/links)?
2. [ ] Are all new documentation files lowercase, with dash separated names (ex. unraid-os.mdx)?
3. [ ] Are all assets (images, etc), located in an assets/ subfolder next to the .md/mdx files?
4. [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
5. [ ] Is the build succeeding?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated release notes for version 7.1.0-beta.4 with a new release date (April 8, 2025).
  - Added guidance on uninstalling the standalone Patch Plugin and clarified wireless adapter diagnostics.

- **Bug Fixes**
  - Fixed an issue causing the mover process to hang.
  - Resolved dashboard loading problems when ad blockers are active.
  - Addressed duplicate default gateway metrics with VLANs and reverted DHCP domain name behavior.
  - Fixed an issue preventing the Array from stopping due to VMs not stopping first.

- **Chores**
  - Enhanced firmware file handling to ensure proper driver initialization.
  - Upgraded the Linux kernel to version 6.12.22.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->