### PR TITLE
feat: enable the docs theme to be set by the parent iframe

### DIFF
--- a/iframe-test.html
+++ b/iframe-test.html
@@ -27,7 +27,7 @@
             border-radius: 5px;
             overflow: hidden;
             box-shadow: 0 2px 4px rgba(0,0,0,0.1);
-            background-color: #fff;
+            background-color: transparent;
         }
         iframe {
             width: 100%;
@@ -56,6 +56,11 @@
         }
         .dimensions input {
             width: 80px;
+        }
+        .theme-controls {
+            margin-top: 10px;
+            display: flex;
+            align-items: center;
         }
     </style>
 </head>
@@ -90,6 +95,15 @@
                 
                 <button id="resize-iframe" style="margin-left: 10px;">Resize</button>
             </div>
+            
+            <div class="theme-controls">
+                <label for="theme-mode">Theme Mode:</label>
+                <select id="theme-mode">
+                    <option value="light" selected>Light</option>
+                    <option value="dark">Dark</option>
+                </select>
+                <button id="apply-theme">Apply Theme</button>
+            </div>
         </div>
         
         <div class="iframe-container">
@@ -107,6 +121,30 @@
             const widthInput = document.getElementById('iframe-width');
             const heightInput = document.getElementById('iframe-height');
             const iframeContainer = document.querySelector('.iframe-container');
+            const themeMode = document.getElementById('theme-mode');
+            const applyThemeButton = document.getElementById('apply-theme');
+            
+            // Function to send theme to iframe
+            function sendThemeToIframe(theme) {
+                iframe.contentWindow.postMessage(
+                    { type: 'theme-update', theme: theme },
+                    '*'
+                );
+            }
+            
+            // Apply theme when button is clicked
+            applyThemeButton.addEventListener('click', function() {
+                const selectedTheme = themeMode.value;
+                sendThemeToIframe(selectedTheme);
+            });
+            
+            // Auto-apply theme when iframe loads
+            iframe.addEventListener('load', function() {
+                // Wait a moment for Docusaurus to initialize
+                setTimeout(() => {
+                    sendThemeToIframe(themeMode.value);
+                }, 500);
+            });
             
             // Load iframe with selected URL
             loadButton.addEventListener('click', function() {
@@ -123,6 +161,27 @@
                     }
                     
                     iframe.src = url;
+                }
+            });
+            
+            // Listen for messages from the iframe
+            window.addEventListener('message', function(event) {
+                // Check if the message is from our iframe
+                if (event.source === iframe.contentWindow) {
+                    // Handle theme-ready message
+                    if (event.data && event.data.type === 'theme-ready') {
+                        console.log('Docusaurus is ready for theme sync');
+                        // Send current theme
+                        sendThemeToIframe(themeMode.value);
+                    }
+                    
+                    // Handle theme change notifications from Docusaurus
+                    if (event.data && event.data.type === 'theme-changed') {
+                        const newTheme = event.data.theme;
+                        // Update the theme dropdown to match
+                        themeMode.value = newTheme;
+                        console.log('Theme changed in Docusaurus to:', newTheme);
+                    }
                 }
             });
             

--- a/src/theme/Layout/IframeNavigation.tsx
+++ b/src/theme/Layout/IframeNavigation.tsx
@@ -1,0 +1,31 @@
+import React, { useEffect, useState } from "react";
+import { useLocation } from "@docusaurus/router";
+import { isInIframe } from "./utils";
+
+/**
+ * Component that handles navigation events between iframe and parent window
+ */
+export function IframeNavigation(): JSX.Element | null {
+  const location = useLocation();
+  const [isInIframeState, setIsInIframeState] = useState(false);
+
+  useEffect(() => {
+    setIsInIframeState(isInIframe());
+  }, []);
+
+  // Handle navigation events
+  useEffect(() => {
+    if (isInIframeState) {
+      window.parent.postMessage({
+        type: 'unraid-docs-navigation',
+        pathname: location.pathname,
+        search: location.search,
+        hash: location.hash,
+        url: window.location.href,
+      }, '*');
+    }
+  }, [location, isInIframeState]);
+
+  // This component doesn't render anything
+  return null;
+} 

--- a/src/theme/Layout/ThemeSync.tsx
+++ b/src/theme/Layout/ThemeSync.tsx
@@ -1,0 +1,57 @@
+import React, { useEffect, useState } from "react";
+import { useColorMode } from "@docusaurus/theme-common";
+import { isInIframe } from "./utils";
+
+/**
+ * Component that handles theme synchronization between iframe and parent window
+ */
+export function ThemeSync(): JSX.Element | null {
+  const [isInIframeState, setIsInIframeState] = useState(false);
+  const { colorMode, setColorMode } = useColorMode();
+  
+  useEffect(() => {
+    setIsInIframeState(isInIframe());
+  }, []);
+  
+  // Handle theme message events from parent
+  useEffect(() => {
+    if (isInIframeState) {
+      const handleMessage = (event) => {
+        // Handle theme update message
+        if (event.data && event.data.type === 'theme-update') {
+          const { theme } = event.data;
+          
+          // Set the theme based on the message
+          if (theme === 'dark' || theme === 'light') {
+            setColorMode(theme);
+          }
+        }
+      };
+
+      // Add event listener
+      window.addEventListener('message', handleMessage);
+      
+      // Send ready message to parent
+      window.parent.postMessage({ type: 'theme-ready' }, '*');
+
+      // Clean up
+      return () => {
+        window.removeEventListener('message', handleMessage);
+      };
+    }
+  }, [isInIframeState, setColorMode]);
+
+  // Notify parent when the theme changes
+  useEffect(() => {
+    if (isInIframeState) {
+      // Send theme change notification to parent
+      window.parent.postMessage({ 
+        type: 'theme-changed', 
+        theme: colorMode 
+      }, '*');
+    }
+  }, [colorMode, isInIframeState]);
+
+  // This component doesn't render anything
+  return null;
+} 

--- a/src/theme/Layout/ThemeSync.tsx
+++ b/src/theme/Layout/ThemeSync.tsx
@@ -17,13 +17,16 @@ export function ThemeSync(): JSX.Element | null {
   useEffect(() => {
     if (isInIframeState) {
       const handleMessage = (event) => {
-        // Handle theme update message
-        if (event.data && event.data.type === 'theme-update') {
-          const { theme } = event.data;
-          
-          // Set the theme based on the message
-          if (theme === 'dark' || theme === 'light') {
-            setColorMode(theme);
+        // Validate the message structure
+        if (event.data && typeof event.data === 'object') {
+          // Handle theme update message
+          if (event.data.type === 'theme-update') {
+            const { theme } = event.data;
+            
+            // Set the theme based on the message
+            if (theme === 'dark' || theme === 'light') {
+              setColorMode(theme);
+            }
           }
         }
       };

--- a/src/theme/Layout/index.tsx
+++ b/src/theme/Layout/index.tsx
@@ -1,36 +1,25 @@
 import React, { useEffect, useState } from "react";
 import Layout from "@theme-original/Layout";
-import { useLocation } from "@docusaurus/router";
-
-function isInIframe() {
-  return typeof window !== 'undefined' && window.self !== window.top;
-}
+import { ThemeSync } from "./ThemeSync";
+import { IframeNavigation } from "./IframeNavigation";
+import { isInIframe } from "./utils";
 
 export default function LayoutWrapper(props) {
-  const location = useLocation();
-  const [isIframe, setIsIframe] = useState(false);
+  const [isInIframeState, setIsInIframeState] = useState(false);
 
   useEffect(() => {
-    setIsIframe(isInIframe());
+    setIsInIframeState(isInIframe());
   }, []);
 
-  useEffect(() => {
-    if (isIframe) {
-      window.parent.postMessage({
-        type: 'unraid-docs-navigation',
-        pathname: location.pathname,
-        search: location.search,
-        hash: location.hash,
-        url: window.location.href,
-      }, '*');
-    }
-  }, [location, isIframe]);
-
-  const dataAttributes = isIframe ? { 'data-iframe': 'true' } : {};
+  const dataAttributes = isInIframeState ? { 'data-iframe': 'true' } : {};
 
   return (
     <div {...dataAttributes}>
-      <Layout {...props} />
+      <Layout {...props}>
+        <ThemeSync />
+        <IframeNavigation />
+        {props.children}
+      </Layout>
     </div>
   );
 }

--- a/src/theme/Layout/utils.ts
+++ b/src/theme/Layout/utils.ts
@@ -1,0 +1,6 @@
+/**
+ * Determines if the current window is running inside an iframe
+ */
+export function isInIframe(): boolean {
+  return typeof window !== 'undefined' && window.self !== window.top;
+} 


### PR DESCRIPTION
Before Submitting This PR, Please Ensure You Have Completed The Following:

1. [ ] Are internal links to wiki documents using [relative file links](https://docusaurus.io/docs/markdown-features/links)?
2. [ ] Are all new documentation files lowercase, with dash separated names (ex. unraid-os.mdx)?
3. [ ] Are all assets (images, etc), located in an assets/ subfolder next to the .md/mdx files?
4. [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
5. [ ] Is the build succeeding?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added theme selection controls with light and dark options and an "Apply Theme" button for iframes.
  - Enabled two-way synchronization of theme settings between parent pages and iframe content.
  - Introduced automatic communication of navigation events from iframe content to parent window.
- **Improvements**
  - Enhanced iframe integration with seamless theme and navigation state sharing for a smoother user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->