### PR TITLE
Update 7.2.0.md

### DIFF
--- a/docs/unraid-os/release-notes/7.2.0.md
+++ b/docs/unraid-os/release-notes/7.2.0.md
@@ -38,7 +38,7 @@ You can now expand your single-vdev RAIDZ1/2/3 pools, one drive at a time:
 * Select the appropriate drive (must be at least as large as the smallest drive in the pool)
 * Start the array
 
-* Fix: There will now be an "invalid expansion" warning (with details in the syslog) if the pool needs to be upgraded first [-beta.2]
+* Fix: There will now be an "invalid expansion" warning if the pool needs to be upgraded first [-beta.2]
 * Improvement: better defaults for ZFS RAIDZ vdevs [-beta.2]
 
 #### Ext2/3/4, NTFS, and exFAT Support


### PR DESCRIPTION
remove  (with details in the syslog) from the raidz expansion error warning.

Before Submitting This PR, Please Ensure You Have Completed The Following:

1. [ ] Are internal links to wiki documents using [relative file links](https://docusaurus.io/docs/markdown-features/links)?
2. [ ] Are all new documentation files lowercase, with dash separated names (ex. unraid-os.mdx)?
3. [ ] Are all assets (images, etc), located in an assets/ subfolder next to the .md/mdx files?
4. [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
5. [ ] Is the build succeeding?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Clarified wording in the Unraid OS 7.2.0 release notes for ZFS RAIDZ expansion warnings, removing the reference to “details in the syslog” to simplify the message.
  - No changes to functionality or behavior: users will still see a warning when a pool requires an upgrade.
  - The 7.2.0-beta.2 designation remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->