### PR TITLE
add go link /go/managing-api-keys

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -489,6 +489,10 @@ const config = {
             to: "/unraid-os/manual/additional-settings/#ups-settings",
             from: "/go/ups-settings",
           },
+          {
+            to: "/API/how-to-use-the-api/#managing-api-keys",
+            from: "/go/managing-api-keys",
+          },
         ],
         createRedirects(existingPath) {
           // Create automatic redirects for release notes paths


### PR DESCRIPTION
Before Submitting This PR, Please Ensure You Have Completed The Following:

1. [ ] Are internal links to wiki documents using [relative file links](https://docusaurus.io/docs/markdown-features/links)?
2. [ ] Are all new documentation files lowercase, with dash separated names (ex. unraid-os.mdx)?
3. [ ] Are all assets (images, etc), located in an assets/ subfolder next to the .md/mdx files?
4. [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
5. [ ] Is the build succeeding?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a client-side redirect so visits to /go/managing-api-keys automatically navigate to the “Managing API Keys” section of the API documentation at /API/how-to-use-the-api/#managing-api-keys.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->