### PR TITLE
Update changing-the-flash-device.md

### DIFF
--- a/docs/unraid-os/system-administration/maintain-and-update/changing-the-flash-device.md
+++ b/docs/unraid-os/system-administration/maintain-and-update/changing-the-flash-device.md
@@ -233,17 +233,15 @@ Never assign a data disk as a %%parity drive|parity-drives%%. Incorrect assignme
 To safely reconfigure your %%array|array%%:
 
 1. Prepare a fresh Unraid flash drive, following the instructions provided earlier in this guide.
-2. Edit `/boot/config/disk.cfg` and set `startArray="no"` to prevent the %%array|array%% from starting automatically.  
-   - Alternatively, you can use ***Settings → Disk Settings*** in the GUI to disable auto-start.
-3. Navigate to ***Tools → New Config*** to create a new %%array|array%% configuration.
+2. Go to Main  
    - Assign all drives as data drives and start the %%array|array%%.
    - Note the serial numbers of drives that do not mount; these are likely your %%parity|parity%% drives.
    - You can also use the [**Unassigned Devices** plugin](https://unraid.net/community/apps?q=unassigned+devices#r:~:text=don%27t%20be%20carefull!!!-,Unassigned%20Devices,-dlandon) to test-mount each drive, identifying %%parity|parity%% by elimination.
-4. Go to ***Tools → New Config*** again and create a new %%array|array%% configuration, retaining all the currently configured drives.
-5. Assign the correct drives as %%parity|parity%% and the rest as data drives in the **Main** tab.
-6. If you have a single %%parity|parity%% drive, the order of data drives is not critical - check **Parity is Valid**. For dual %%parity|parity%%, both the order of the data drives and the assignment of parity1 and parity2 are important.  Parity1 and parity2 are not interchangeable, and %%parity|parity%% must be rebuilt.
-7. Start the %%array|array%% to commit assignments. Data drives should mount, and their contents should remain intact.
-8. If you checked **Parity is Valid**, run a correcting [%%parity|parity%% check](../../using-unraid-to/manage-storage/array-configuration.md#checking-array-devices) to confirm that your configuration is correct.
+3. Go to ***Tools → New Config*** again and create a new %%array|array%% configuration, retaining all the currently configured drives.
+4. Assign the correct drives as %%parity|parity%% and the rest as data drives in the **Main** tab.
+5. If you have a single %%parity|parity%% drive, the order of data drives is not critical - check **Parity is Valid**. For dual %%parity|parity%%, both the order of the data drives and the assignment of parity1 and parity2 are important.  Parity1 and parity2 are not interchangeable, and %%parity|parity%% must be rebuilt.
+6. Start the %%array|array%% to commit assignments. Data drives should mount, and their contents should remain intact.
+7. If you checked **Parity is Valid**, run a correcting [%%parity|parity%% check](../../using-unraid-to/manage-storage/array-configuration.md#checking-array-devices) to confirm that your configuration is correct.
 
 :::note
 After restoring your %%array|array%%, verify any share-specific include/exclude settings, as the order of data drives may have changed.

--- a/docs/unraid-os/system-administration/maintain-and-update/changing-the-flash-device.md
+++ b/docs/unraid-os/system-administration/maintain-and-update/changing-the-flash-device.md
@@ -237,7 +237,7 @@ To safely reconfigure your %%array|array%%:
    - Assign all drives as data drives and start the %%array|array%%.
    - Note the serial numbers of drives that do not mount; these are likely your %%parity|parity%% drives.
    - Do not click **Format** on any drive. If more unmountable drives appear than expected %%parity|parity%% drives, stop and seek help in the forums.
-   - You can also use the [**Unassigned Devices** plugin](https://unraid.net/community/apps?q=unassigned+devices#r:~:text=don%27t%20be%20carefull!!!-,Unassigned%20Devices,-dlandon) to test-mount each drive, identifying %%parity|parity%% by elimination.
+   - You can also use the [Unassigned Devices plugin](https://unraid.net/community/apps?q=Unassigned%20Devices) to test‑mount each drive (%%parity|parity%% will not mount), identifying %%parity|parity%% by elimination.
    - Stop the %%array|array%% before proceeding.
 3. Go to ***Tools → New Config*** and create a new %%array|array%% configuration, retaining all the currently configured drives.
 4. Assign the correct drives as %%parity|parity%% and the rest as data drives in the **Main** tab.

--- a/docs/unraid-os/system-administration/maintain-and-update/changing-the-flash-device.md
+++ b/docs/unraid-os/system-administration/maintain-and-update/changing-the-flash-device.md
@@ -233,13 +233,15 @@ Never assign a data disk as a %%parity drive|parity-drives%%. Incorrect assignme
 To safely reconfigure your %%array|array%%:
 
 1. Prepare a fresh Unraid flash drive, following the instructions provided earlier in this guide.
-2. Go to Main  
+2. Go to the ***Main*** tab  
    - Assign all drives as data drives and start the %%array|array%%.
    - Note the serial numbers of drives that do not mount; these are likely your %%parity|parity%% drives.
+   - Do not click **Format** on any drive. If more unmountable drives appear than expected %%parity|parity%% drives, stop and seek help in the forums.
    - You can also use the [**Unassigned Devices** plugin](https://unraid.net/community/apps?q=unassigned+devices#r:~:text=don%27t%20be%20carefull!!!-,Unassigned%20Devices,-dlandon) to test-mount each drive, identifying %%parity|parity%% by elimination.
-3. Go to ***Tools → New Config*** again and create a new %%array|array%% configuration, retaining all the currently configured drives.
+   - Stop the %%array|array%% before proceeding.
+3. Go to ***Tools → New Config*** and create a new %%array|array%% configuration, retaining all the currently configured drives.
 4. Assign the correct drives as %%parity|parity%% and the rest as data drives in the **Main** tab.
-5. If you have a single %%parity|parity%% drive, the order of data drives is not critical - check **Parity is Valid**. For dual %%parity|parity%%, both the order of the data drives and the assignment of parity1 and parity2 are important.  Parity1 and parity2 are not interchangeable, and %%parity|parity%% must be rebuilt.
+5. If you have a single %%parity|parity%% drive, the order of data drives is not critical. Check **Parity is Valid** only if you are certain you assigned the same physical parity disk and no writes occurred since the original configuration. For dual %%parity|parity%%, both the order of the data drives and the assignment of parity1 and parity2 are important—parity1 and parity2 are not interchangeable, and %%parity|parity%% must be rebuilt if either is changed.
 6. Start the %%array|array%% to commit assignments. Data drives should mount, and their contents should remain intact.
 7. If you checked **Parity is Valid**, run a correcting [%%parity|parity%% check](../../using-unraid-to/manage-storage/array-configuration.md#checking-array-devices) to confirm that your configuration is correct.
 


### PR DESCRIPTION
Removed some extra steps that are not needed and can confuse the user

Before Submitting This PR, Please Ensure You Have Completed The Following:

1. [ ] Are internal links to wiki documents using [relative file links](https://docusaurus.io/docs/markdown-features/links)?
2. [ ] Are all new documentation files lowercase, with dash separated names (ex. unraid-os.mdx)?
3. [ ] Are all assets (images, etc), located in an assets/ subfolder next to the .md/mdx files?
4. [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
5. [ ] Is the build succeeding?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Rewrote array reconfiguration guide to a UI-driven workflow that identifies parity drives by elimination via Main/Tools flows.
  * Removed instructions for disabling auto-start (previous GUI and file-edit alternatives).
  * Reordered steps to start at Main, test drive mounting to identify parity, then use New Config to assign roles.
  * Clarified single vs dual parity handling, stopping/starting the array to commit, parity validation, and post-restore share checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->