### PR TITLE
Update array-configuration.md

### DIFF
--- a/docs/unraid-os/using-unraid-to/manage-storage/array-configuration.md
+++ b/docs/unraid-os/using-unraid-to/manage-storage/array-configuration.md
@@ -717,14 +717,14 @@ If you're comfortable using the Linux command line, you can manually zero out yo
    umount /mnt/diskX
    ```
 2. With newer releases we need to mount a dummy fs image in place of the disk that we unmounted, or the array won't stop in the end:
-   
+
     ```bash
    truncate -s 400M /tmp/xmini.img
    mkfs.xfs -f /tmp/xmini.img > /dev/null
    mount /tmp/xmini.img /mnt/diskX  
    ```
-    
-4. Zero out the disk with the following command:
+
+3. Zero out the disk with the following command:
    ```bash
    dd bs=1M if=/dev/zero of=/dev/mdXp1 status=progress
    ```


### PR DESCRIPTION
With v6.12 and newer, stop array will be stuck in a retry loop if we don't mount a dummy fs in place of the one that was unmounted.

Before Submitting This PR, Please Ensure You Have Completed The Following:

1. [ ] Are internal links to wiki documents using [relative file links](https://docusaurus.io/docs/markdown-features/links)?
2. [ ] Are all new documentation files lowercase, with dash separated names (ex. unraid-os.mdx)?
3. [ ] Are all assets (images, etc), located in an assets/ subfolder next to the .md/mdx files?
4. [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
5. [ ] Is the build succeeding?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated array configuration guide for newer Unraid releases.
  * Manual disk-zeroing procedure now instructs creating and mounting a temporary 400MB filesystem image before zeroing; steps reordered so zeroing runs after the dummy mount.
  * Parity-preserve alternative updated for 6.12+ to include the dummy-image mount; 6.11 and earlier paths unchanged.
  * Zeroing command itself unchanged; wording clarified for compatibility and safety.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->