### PR TITLE
feat: per lang edit urls

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -35,6 +35,7 @@ jobs:
         run: npm run build -- --locale en
         env:
           BASE_URL: /docs/pr-preview/pr-${{ github.event.number }}/
+          GITHUB_BRANCH: ${{ github.head_ref }}
       
       - name: Deploy PR Preview
         uses: rossjrw/pr-preview-action@v1

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -61,7 +61,9 @@ module.exports = async function createConfigAsync() {
                 return `https://translate.unraid.net/unraid-docs/${locale}`;
               }
               // Link to GitHub for English docs
-              return `https://github.com/unraid/docs/edit/main/${versionDocsDirPath}/${docPath}`;
+              // Use PR branch if available, otherwise default to main
+              const branch = process.env.GITHUB_BRANCH || 'main';
+              return `https://github.com/unraid/docs/edit/${branch}/${versionDocsDirPath}/${docPath}`;
             },
             editLocalizedFiles: true,
             async sidebarItemsGenerator({


### PR DESCRIPTION
Before Submitting This PR, Please Ensure You Have Completed The Following:

1. [ ] Are internal links to wiki documents using [relative file links](https://docusaurus.io/docs/markdown-features/links)?
2. [ ] Are all new documentation files lowercase, with dash separated names (ex. unraid-os.mdx)?
3. [ ] Are all assets (images, etc), located in an assets/ subfolder next to the .md/mdx files?
4. [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
5. [ ] Is the build succeeding?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * “Edit this page” links are now locale-aware: English pages open the GitHub edit view (using the current PR branch when available) for direct edits, while non-English pages link to the translation portal to suggest or improve translations. The site’s default locale remains English and existing doc behavior is preserved otherwise.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->