### PR TITLE
Update 7.2.0.md

### DIFF
--- a/docs/unraid-os/release-notes/7.2.0.md
+++ b/docs/unraid-os/release-notes/7.2.0.md
@@ -70,7 +70,7 @@ The ***Main*** page will now warn if any array or pool drives are formatted with
 - Fix: Shares with invalid characters in names could not be deleted or modified \[-beta.2]
 - Fix: Correct handling of case-insensitive share names \[-beta.3]
 - Fix: BTRFS array disks with multiple filesystem signatures don't mount \[-beta.3]
-- Fix: Resolved some issues with existing 1MiB aligned partitions \[-beta.3]
+- Fix: Resolved some issues for parity disks with existing 1MiB aligned partitions \[-beta.3]
 - Improvement: Add **File system status** to **DeviceInfo** page, showing whether a drive is mounted/unmounted and empty/not empty \[-beta.3]
 
 ### Networking


### PR DESCRIPTION
Making it more clear what this is about, SSDs use 1MiB aligned partitions, to avoid users thinking there were issues with those.

Before Submitting This PR, Please Ensure You Have Completed The Following:

1. [ ] Are internal links to wiki documents using [relative file links](https://docusaurus.io/docs/markdown-features/links)?
2. [ ] Are all new documentation files lowercase, with dash separated names (ex. unraid-os.mdx)?
3. [ ] Are all assets (images, etc), located in an assets/ subfolder next to the .md/mdx files?
4. [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
5. [ ] Is the build succeeding?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified wording in Unraid OS 7.2.0 release notes under Storage > Other storage changes to specify the fix applies to parity disks with existing 1MiB-aligned partitions.
  * Improves clarity for users reviewing storage-related fixes and reduces ambiguity about the affected devices.
  * No functional or behavioral changes to the product; this is an editorial update only.
  * No user action required; the change refines the description to better reflect the scope of the fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->