### PR TITLE
fix /go/check-filesystem/

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -384,7 +384,7 @@ const config: Config = {
     { from: "/go/advanced-bios-config/", to: "/unraid-os/getting-started/set-up-unraid/create-your-bootable-media/" },
     { from: "/go/applications/", to: "/unraid-os/using-unraid-to/run-docker-containers/community-applications/" },
     { from: "/go/changing-the-flash-device/", to: "/unraid-os/system-administration/maintain-and-update/changing-the-flash-device/" },
-    { from: "/go/check-filesystem/", to: "/unraid-os/using-unraid-to/manage-storage/array-configuration/#checking-array-devices" },
+    { from: "/go/check-filesystem/", to: "/unraid-os/using-unraid-to/manage-storage/file-systems/#checking-a-file-system" },
     { from: "/go/convert-reiser-and-xfs/", to: "/unraid-os/using-unraid-to/manage-storage/file-systems/#converting-to-a-new-file-system-type" },
     { from: "/go/configuring-vpn-tunneledaccess-for-system/", to: "/unraid-os/system-administration/secure-your-server/wireguard/#configuring-vpn-tunneled-access-for-system" },
     { from: "/go/connect-about/", to: "/unraid-connect/overview-and-setup/" },


### PR DESCRIPTION
Before Submitting This PR, Please Ensure You Have Completed The Following:

1. [ ] Are internal links to wiki documents using [relative file links](https://docusaurus.io/docs/markdown-features/links)?
2. [ ] Are all new documentation files lowercase, with dash separated names (ex. unraid-os.mdx)?
3. [ ] Are all assets (images, etc), located in an assets/ subfolder next to the .md/mdx files?
4. [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
5. [ ] Is the build succeeding?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the /go/check-filesystem/ short link to redirect to the “Checking a file system” guide for more accurate guidance when troubleshooting file systems.
  * Improves navigation by taking users directly to the most relevant content; no user action required and existing bookmarks continue to work via redirect.
  * All other short-link redirects remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->