### PR TITLE
Update array-configuration.mdx

### DIFF
--- a/docs/unraid-os/using-unraid-to/manage-storage/array-configuration.mdx
+++ b/docs/unraid-os/using-unraid-to/manage-storage/array-configuration.mdx
@@ -804,7 +804,7 @@ You can choose from two methods to remove a data disk:
 
       3. Zero out the disk with the following command:
          ```bash
-         dd bs=1M if=/dev/zero of=/dev/mdXp1 status=progress
+         dd bs=1M if=/dev/zero of=/dev/mdXp1 bs=4K status=progress
          ```
 
       **For Unraid 6.11 and earlier:**
@@ -815,7 +815,7 @@ You can choose from two methods to remove a data disk:
          ```
       2. Next, use this command to zero out the disk:
          ```bash
-         dd bs=1M if=/dev/zero of=/dev/mdX status=progress
+         dd bs=1M if=/dev/zero of=/dev/mdX bs=4K status=progress
          ```
 
       :::note


### PR DESCRIPTION
Just noticed that the dd commands are missing the block size option. This means using a 512B block size, which can be much slower.

Before Submitting This PR, Please Ensure You Have Completed The Following:

1. [ ] Are internal links to wiki documents using [relative file links](https://docusaurus.io/docs/markdown-features/links)?
2. [ ] Are all new documentation files lowercase, with dash separated names (ex. unraid-os.mdx)?
3. [ ] Are all assets (images, etc), located in an assets/ subfolder next to the .md/mdx files?
4. [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
5. [ ] Is the build succeeding?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated disk zeroing commands in the Unraid array configuration guide to use a 4K block size for dd.
  - Clarifies parity-related procedures with corrected examples, improving consistency with typical disk sector sizes.
  - Enhances reliability and readability of the step-by-step instructions for preparing drives.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->