### PR TITLE
feat: add custom domain routing for documentation site

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -3,5 +3,11 @@
   "compatibility_date": "2025-09-12",
   "assets": {
     "directory": "./build"
-  }
+  },
+  "routes": [
+    {
+      "pattern": "docs.unraid.net",
+      "custom_domain": true
+    }
+  ]
 }


### PR DESCRIPTION
Before Submitting This PR, Please Ensure You Have Completed The Following:

1. [ ] Are internal links to wiki documents using [relative file links](https://docusaurus.io/docs/markdown-features/links)?
2. [ ] Are all new documentation files lowercase, with dash separated names (ex. unraid-os.mdx)?
3. [ ] Are all assets (images, etc), located in an assets/ subfolder next to the .md/mdx files?
4. [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
5. [ ] Is the build succeeding?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Documentation is now available at the custom domain docs.unraid.net for easier, direct access.
* **Chores**
  * Updated deployment configuration to enable the new documentation domain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->