### PR TITLE
fix: robots.txt algolia options

### DIFF
--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,3 +1,6 @@
+User-agent: Algolia Crawler
+Allow: /
+
 User-agent: *
 Disallow: /zh/
 Disallow: /es/

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -2,9 +2,10 @@ User-agent: Algolia Crawler
 Allow: /
 
 User-agent: *
-Disallow: /zh/
-Disallow: /es/
-Disallow: /fr/
-Disallow: /de/
+Allow: /
 
 Sitemap: https://docs.unraid.net/sitemap.xml
+Sitemap: https://docs.unraid.net/zh/sitemap.xml
+Sitemap: https://docs.unraid.net/es/sitemap.xml
+Sitemap: https://docs.unraid.net/fr/sitemap.xml
+Sitemap: https://docs.unraid.net/de/sitemap.xml


### PR DESCRIPTION
Before Submitting This PR, Please Ensure You Have Completed The Following:

1. [ ] Are internal links to wiki documents using [relative file links](https://docusaurus.io/docs/markdown-features/links)?
2. [ ] Are all new documentation files lowercase, with dash separated names (ex. unraid-os.mdx)?
3. [ ] Are all assets (images, etc), located in an assets/ subfolder next to the .md/mdx files?
4. [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
5. [ ] Is the build succeeding?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated robots.txt to allow the Algolia Crawler across the site (Allow: /).
  - Retained existing rules for all user agents disallowing /zh/, /es/, /fr/, and /de/.
  - Added a sitemap directive pointing to https://docs.unraid.net/sitemap.xml.
  - Adjusts crawler access and sitemap discovery for the documentation site; no product features affected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->