### PR TITLE
chore: associate .mdx with markdown

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,5 +14,8 @@
     ],
     "cSpell.customDictionaries": {
 
+    },
+    "files.associations": {
+        "*.mdx": "markdown"
     }
 }


### PR DESCRIPTION
Before Submitting This PR, Please Ensure You Have Completed The Following:

1. [ ] Are internal links to wiki documents using [relative file links](https://docusaurus.io/docs/markdown-features/links)?
2. [ ] Are all new documentation files lowercase, with dash separated names (ex. unraid-os.mdx)?
3. [ ] Are all assets (images, etc), located in an assets/ subfolder next to the .md/mdx files?
4. [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
5. [ ] Is the build succeeding?
