### PR TITLE
docs(footer): add Crowdin translation link

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -228,8 +228,12 @@ const config: Config = {
           items: [
             { label: "Home", to: "/" },
             {
-              label: "Contribute on Github",
+              label: "Contribute on GitHub",
               href: "https://github.com/unraid/docs",
+            },
+            {
+              label: "Contribute translations",
+              href: "https://unraid.crowdin.com/unraid-docs",
             },
           ],
         },


### PR DESCRIPTION
## Summary
- Add a footer link for translation contributors to the Unraid Docs Crowdin project
- Rename the existing footer contribution link to use the correct GitHub capitalization

## Validation
- pnpm exec prettier --check docusaurus.config.ts
- git diff --check -- docusaurus.config.ts

Full Docusaurus build was not run, per repo guidance for routine validation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new footer link for contributing translations to the documentation.

* **Documentation**
  * Corrected capitalization in the GitHub contribution footer link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->