### PR TITLE
docs: add Unraid OS 7.2.5 release note

### DIFF
--- a/docs/unraid-os/release-notes/7.2.5.md
+++ b/docs/unraid-os/release-notes/7.2.5.md
@@ -34,7 +34,7 @@ If rolling back earlier than 7.2.4, also see the [7.2.4 release notes](/unraid-o
 
 ### Unraid API
 
-- Updated to version v4.32.1 - [release notes](https://github.com/unraid/api/releases)
+- Updated to version v4.32.2 - [release notes](https://github.com/unraid/api/releases)
 - Fix: Improve registration-state refresh after license updates so the WebGUI reflects the current license state more reliably.
 
 ### Linux kernel

--- a/docs/unraid-os/release-notes/7.2.5.md
+++ b/docs/unraid-os/release-notes/7.2.5.md
@@ -1,0 +1,46 @@
+# Version 7.2.5-rc.1 2026-04-15
+
+This release updates Docker for Unraid 7.2.x users and includes targeted fixes for Docker, Tailscale, mover empty-disk workflows, login-page custom case images, and registration state handling.
+
+This release is recommended for all 7.2.x users.
+
+## Upgrading
+
+For step-by-step instructions, see [Upgrading Unraid](/unraid-os/system-administration/maintain-and-update/upgrading-unraid/). Questions about your [license](/unraid-os/troubleshooting/licensing-faq/)?
+
+### Known issues
+
+For other known issues, see the [7.2.4 release notes](/unraid-os/release-notes/7.2.4/).
+
+### Rolling back
+
+If rolling back earlier than 7.2.4, also see the [7.2.4 release notes](/unraid-os/release-notes/7.2.4/).
+
+## Changes vs. [7.2.4](/unraid-os/release-notes/7.2.4/)
+
+### Containers / Docker
+
+- Improvement: Update Docker to version 29 for 7.2.x systems.
+- Fix: Hide stale dead or uninspectable "ghost" containers from the Docker page without deleting containers or mutating Docker state.
+- Fix: Clear stale Tailscale Serve/Funnel state when a Docker container restarts, then reapply only the Serve/Funnel mode currently configured in the Docker template. This prevents a container changed from Funnel or Serve to No from keeping the old exposure active after restart.
+
+### Storage
+
+- Fix: Keep the mover empty-disk action available on systems with user shares enabled but no pool devices assigned, while still disabling it during parity, mover, and BTRFS operations.
+
+### WebGUI
+
+- Fix: Restore custom case-model images on the login page
+
+### Unraid API
+
+- Updated to version v4.32.1 - [release notes](https://github.com/unraid/api/releases)
+- Fix: Improve registration-state refresh after license updates so the WebGUI reflects the current license state more reliably.
+
+### Linux kernel
+
+- version 6.12.54-Unraid (no change)
+
+### Base distro updates
+
+- docker: version 29


### PR DESCRIPTION
## Summary

- Add the Unraid OS `7.2.5` release-note page.
- Document the `7.2.5-rc.1` upgrade, known-issue, rollback, and changes-vs-`7.2.4` sections.
- Capture Docker 29, Docker/Tailscale fixes, mover empty-disk availability, login-page custom case images, API registration-state refresh, kernel status, and base distro updates.

## Validation

- `pnpm exec remark docs/unraid-os/release-notes/7.2.5.md --quiet --frail`
- Full build intentionally not run, per `AGENTS.md` guidance for this repo.

## Checklist

Before Submitting This PR, Please Ensure You Have Completed The Following:

1. [x] Are internal links to wiki documents using [relative file links](https://docusaurus.io/docs/markdown-features/links)? No wiki document links added.
2. [x] Are all new documentation files lowercase, with dash separated names (ex. unraid-os.mdx)? This follows the existing release-note version filename pattern.
3. [x] Are all assets (images, etc), located in an assets/ subfolder next to the .md/mdx files? No assets added.
4. [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change? No existing PR for this branch.
5. [ ] Is the build succeeding? Not run locally, per repo validation guidance.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Adds Unraid OS 7.2.5-rc.1 release notes with upgrade and rollback guidance and known-issues links; recommended for all 7.2.x users.

* **New Features**
  * Docker upgraded to v29: hides stale/“ghost” containers without mutating state and clears stale Tailscale Serve/Funnel state on container restart.
  * Storage: mover empty-disk action available when shares enabled but no pool devices; disabled during parity/mover/BTRFS ops.
  * WebGUI: restores custom case-model login images.
  * Unraid API bumped to v4.32.2 with improved license-state refresh.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->