### PR TITLE
Revise data recovery ddrescue instructions

### DIFF
--- a/docs/unraid-os/troubleshooting/common-issues/data-recovery.mdx
+++ b/docs/unraid-os/troubleshooting/common-issues/data-recovery.mdx
@@ -247,12 +247,7 @@ Before you begin, remember that data recovery is a delicate process. Always work
 
 :::
 
-The recommended method to install ddrescue is through the **[Nerd Tools](https://unraid.net/community/apps?q=nerd+tools#r)** plugin (which replaced the deprecated NerdPack in 2022).
-
-To enable ddrescue:
-
-1. Install [Nerd Tools](https://unraid-production-481d40bf.preview.craft.cloud/community/apps?q=nerd+tools#r:~:text=of%201%20App-,Nerd%20Tools,-unRaid.es) from the **Apps** tab in the Unraid %%WebGUI|web-gui%%.
-2. Open ***Settings → Nerd Tools*** and enable **ddrescue**.
+The recommended method to install ddrescue is through the **[ddrescue](https://ca.unraid.net/apps?q=ddrescue&type=plugin)** plugin (which needs used as Nerd Tools and NerdPack are both depreciated). Once the `ddrescue` plugin is installed, you can continue with the directions below.
 
 ### Cloning a failing disk
 

--- a/docs/unraid-os/troubleshooting/common-issues/data-recovery.mdx
+++ b/docs/unraid-os/troubleshooting/common-issues/data-recovery.mdx
@@ -247,7 +247,7 @@ Before you begin, remember that data recovery is a delicate process. Always work
 
 :::
 
-The recommended method to install ddrescue is through the **[ddrescue](https://ca.unraid.net/apps?q=ddrescue&type=plugin)** plugin (which needs used as Nerd Tools and NerdPack are both depreciated). Once the `ddrescue` plugin is installed, you can continue with the directions below.
+The recommended method to install ddrescue is through the **[ddrescue](https://ca.unraid.net/apps?q=ddrescue&type=plugin)** plugin, because Nerd Tools and NerdPack are both deprecated. Once the `ddrescue` plugin is installed, you can continue with the directions below.
 
 ### Cloning a failing disk
 


### PR DESCRIPTION
This pull request updates the recommended installation method for `ddrescue` in the Unraid OS data recovery documentation. The instructions now point users to the dedicated `ddrescue` plugin instead of the deprecated `Nerd Tools` or `NerdPack` plugins.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated data recovery troubleshooting guide with current installation instructions for ddrescue, reflecting changes in available installation methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->