### PR TITLE
docs: update Unraid OS 7.2.5-rc.2 changelog

### DIFF
--- a/docs/unraid-os/release-notes/7.2.5.md
+++ b/docs/unraid-os/release-notes/7.2.5.md
@@ -1,4 +1,4 @@
-# Version 7.2.5 2026-04-20
+# Version 7.2.5-rc.2 2026-04-20
 
 This security and bugfix release updates Docker and the Linux kernel for Unraid 7.2.x users. It also includes targeted fixes for Docker, Tailscale, mover empty-disk workflows, login-page custom case images, and registration state handling.
 
@@ -18,7 +18,7 @@ For other known issues, see the [7.2.4 release notes](/unraid-os/release-notes/7
 
 If rolling back earlier than 7.2.4, also see the [7.2.4 release notes](/unraid-os/release-notes/7.2.4/).
 
-## Changes vs. [7.2.4](/unraid-os/release-notes/7.2.4/)
+## Changes from rc.1
 
 ### Containers / Docker
 
@@ -43,6 +43,10 @@ If rolling back earlier than 7.2.4, also see the [7.2.4 release notes](/unraid-o
 
 - version 6.12.82-Unraid
 - Security: Pick up upstream fixes for CVE-2026-31430, a Linux X.509 out-of-bounds access issue triggered by specially crafted certificates.
+
+### System
+
+- Fix: Add a mitigation for a rare crash.
 
 ### Base distro updates
 

--- a/docs/unraid-os/release-notes/7.2.5.md
+++ b/docs/unraid-os/release-notes/7.2.5.md
@@ -20,7 +20,11 @@ If rolling back earlier than 7.2.4, also see the [7.2.4 release notes](/unraid-o
 
 ## Changes from rc.1
 
-Only the Linux kernel update and rare-crash mitigation are new in rc.2.
+Only the Unraid API update, Linux kernel update, and rare-crash mitigation are new in rc.2.
+
+### Unraid API
+
+- dynamix.unraid.net 4.32.3 - [see changes](https://github.com/unraid/api/releases)
 
 ### Linux kernel
 
@@ -49,7 +53,6 @@ Only the Linux kernel update and rare-crash mitigation are new in rc.2.
 
 ### Unraid API
 
-- dynamix.unraid.net 4.32.3 - [see changes](https://github.com/unraid/api/releases)
 - Fix: Improve registration-state refresh after license updates so the WebGUI reflects the current license state more reliably.
 
 ### Base distro updates

--- a/docs/unraid-os/release-notes/7.2.5.md
+++ b/docs/unraid-os/release-notes/7.2.5.md
@@ -1,6 +1,8 @@
-# Version 7.2.5-rc.1 2026-04-15
+# Version 7.2.5 2026-04-20
 
-This release updates Docker for Unraid 7.2.x users and includes targeted fixes for Docker, Tailscale, mover empty-disk workflows, login-page custom case images, and registration state handling.
+This security and bugfix release updates Docker and the Linux kernel for Unraid 7.2.x users. It also includes targeted fixes for Docker, Tailscale, mover empty-disk workflows, login-page custom case images, and registration state handling.
+
+The Docker update includes runc fixes for CVE-2025-31133, CVE-2025-52565, and CVE-2025-52881.
 
 This release is recommended for all 7.2.x users.
 
@@ -34,12 +36,13 @@ If rolling back earlier than 7.2.4, also see the [7.2.4 release notes](/unraid-o
 
 ### Unraid API
 
-- Updated to version v4.32.2 - [release notes](https://github.com/unraid/api/releases)
+- dynamix.unraid.net 4.32.2 - [see changes](https://github.com/unraid/api/releases)
 - Fix: Improve registration-state refresh after license updates so the WebGUI reflects the current license state more reliably.
 
 ### Linux kernel
 
-- version 6.12.54-Unraid (no change)
+- version 6.12.82-Unraid
+- Security: Pick up upstream fixes for CVE-2026-31430, a Linux X.509 out-of-bounds access issue triggered by specially crafted certificates.
 
 ### Base distro updates
 

--- a/docs/unraid-os/release-notes/7.2.5.md
+++ b/docs/unraid-os/release-notes/7.2.5.md
@@ -36,7 +36,7 @@ If rolling back earlier than 7.2.4, also see the [7.2.4 release notes](/unraid-o
 
 ### Unraid API
 
-- dynamix.unraid.net 4.32.2 - [see changes](https://github.com/unraid/api/releases)
+- dynamix.unraid.net 4.32.3 - [see changes](https://github.com/unraid/api/releases)
 - Fix: Improve registration-state refresh after license updates so the WebGUI reflects the current license state more reliably.
 
 ### Linux kernel

--- a/docs/unraid-os/release-notes/7.2.5.md
+++ b/docs/unraid-os/release-notes/7.2.5.md
@@ -20,6 +20,19 @@ If rolling back earlier than 7.2.4, also see the [7.2.4 release notes](/unraid-o
 
 ## Changes from rc.1
 
+Only the Linux kernel update and rare-crash mitigation are new in rc.2.
+
+### Linux kernel
+
+- version 6.12.82-Unraid
+- Security: Pick up upstream fixes for CVE-2026-31430, a Linux X.509 out-of-bounds access issue triggered by specially crafted certificates.
+
+### System
+
+- Fix: Add a mitigation for a rare crash.
+
+## Included from rc.1
+
 ### Containers / Docker
 
 - Improvement: Update Docker to version 29 for 7.2.x systems.
@@ -38,15 +51,6 @@ If rolling back earlier than 7.2.4, also see the [7.2.4 release notes](/unraid-o
 
 - dynamix.unraid.net 4.32.3 - [see changes](https://github.com/unraid/api/releases)
 - Fix: Improve registration-state refresh after license updates so the WebGUI reflects the current license state more reliably.
-
-### Linux kernel
-
-- version 6.12.82-Unraid
-- Security: Pick up upstream fixes for CVE-2026-31430, a Linux X.509 out-of-bounds access issue triggered by specially crafted certificates.
-
-### System
-
-- Fix: Add a mitigation for a rare crash.
 
 ### Base distro updates
 


### PR DESCRIPTION
## Summary
- Change the 7.2.5 release note title to 7.2.5-rc.2 dated 2026-04-20.
- Make the rc.2 delta explicit: the Unraid API 4.32.3 update, Linux kernel update, and rare-crash mitigation are new from rc.1.
- Keep carried-forward Docker, storage, WebGUI, API registration-state, and base distro entries under an "Included from rc.1" section.

## Validation
- pnpm exec remark docs/unraid-os/release-notes/7.2.5.md --quiet --frail
- git diff --check

Full build intentionally not run, per repo guidance for routine docs validation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * 7.2.5-rc.2 release notes updated to reflect a Docker + Linux kernel security/stability release.

* **Security**
  * runc fixes for CVE-2025-31133, CVE-2025-52565, CVE-2025-52881.
  * Linux kernel X.509 fix for CVE-2026-31430.

* **Bug Fixes**
  * Rare system crash mitigation added.
  * Kernel updated to 6.12.82-Unraid.

* **Updates**
  * Unraid API reference updated to dynamix.unraid.net 4.32.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->