### PR TITLE
docs(internal-boot): explain why to choose internal boot

### DIFF
--- a/docs/unraid-os/getting-started/set-up-unraid/internal-boot-faq.mdx
+++ b/docs/unraid-os/getting-started/set-up-unraid/internal-boot-faq.mdx
@@ -35,6 +35,19 @@ This page contains frequently asked questions about internal boot in Unraid OS. 
   </div>
 </details>
 
+### Why would I use internal boot instead of a USB flash drive? {/* #internal-boot-benefits */}
+
+Internal boot is optional. If your USB flash boot setup is reliable and fits your server, you do not need to switch just because internal boot exists.
+
+Internal boot solves a few practical problems:
+
+- It reduces reliance on USB flash media. Internal SSD, NVMe, or eMMC devices are generally more durable than inexpensive USB flash drives and are less likely to be bumped, removed, or damaged.
+- It supports mirrored boot devices. With two internal boot devices, Unraid can continue booting if one device fails.
+- It works better for systems where USB boot is awkward, exposed, unreliable, or not preferred by the hardware design.
+- It lets you choose a dedicated boot pool for boot-only devices, or a boot + data pool when you want to reserve part of a larger device for boot and use the remaining capacity as a normal pool.
+
+Internal boot does not make the array faster during normal operation, and it is not required for servers that are already booting reliably from USB.
+
 ### I switched from flash boot to internal boot, but the system still boots from flash. What should I do? {#internal-boot-bios-order}
 
 Unraid attempts to update the UEFI boot order automatically. If that does not take effect, manually move your internal boot device(s) to the top of your BIOS/UEFI boot order, save changes, and reboot.


### PR DESCRIPTION
## Summary\n- add a new Internal Boot FAQ entry for the practical benefits of the feature\n- explain that internal boot is optional, not a required upgrade\n- focus the list on durability, boot-device redundancy, hardware-fit, and boot-pool mode choices\n\n## Validation\n- pnpm run lint:mdx\n  - completed successfully\n  - emitted a local Node engine warning because this shell is on Node v25 while the repo expects >=22 <25

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new FAQ section explaining when to use internal boot versus USB flash drive boot, including practical scenarios such as addressing USB durability concerns, providing boot redundancy options, and improving system compatibility. Clarifies that internal boot does not impact standard array performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->