### PR TITLE
feat: Update 7.3.0 rc.1 release notes

### DIFF
--- a/docs/unraid-os/release-notes/7.3.0.md
+++ b/docs/unraid-os/release-notes/7.3.0.md
@@ -1,8 +1,8 @@
-# Version 7.3.0-beta.2 2026-04-01
+# Version 7.3.0-rc.1 2026-04-22
 
-This beta adds dedicated boot pool support and fixes user-facing regressions reported against 7.3.0-beta.1, especially around Docker behavior, XFS sector-size compatibility, onboarding polish, and device configuration.
+This release candidate includes onboarding and internal boot, TPM-based licensing, Docker and storage improvements, WebGUI improvements, virtualization updates, hardware support, and platform package updates.
 
-This is BETA software. Please use on test servers only.
+This is RELEASE CANDIDATE software. Please use on test servers only.
 
 ## Upgrading
 
@@ -12,7 +12,11 @@ For step-by-step instructions, see [Upgrading Unraid](/unraid-os/system-administ
 
 See [Unraid OS Prerelease (Bugs & Feedback)](https://product.unraid.net/b/unraid-os-prerelease-bugs-feedback) for issues reported by other testers.
 
-- If you customized `/boot/syslinux/syslinux.cfg` before switching to internal boot, save a copy first. After migrating, reapply those custom boot settings under **Main → Boot Device → Boot → Boot Parameters**. If you already migrated, restore `syslinux.cfg` from backup before reapplying those changes.
+- During internal boot setup, the WebGUI may show **Array Offline** while internal boot configures. **DO NOT** manually restart or remove your flash drive during this process.
+- Internal boot requires boot storage that can be accessed by in-tree Linux drivers during startup. Devices that require third-party drivers or post-boot configuration cannot be used for internal boot.
+
+### Notes
+
 - Adding, removing, and replacing devices in the ZFS boot pool generally works correctly. One exception: if you start with a dedicated boot pool made from two small devices and replace them one at a time with larger devices, the pool may convert to a split pool.
 - When boot-pool devices are added, removed, or replaced, Unraid does not currently update the server BIOS boot priority automatically. After making those changes, verify the BIOS boot order manually.
 
@@ -25,62 +29,32 @@ See [Unraid OS Prerelease (Bugs & Feedback)](https://product.unraid.net/b/unraid
 
 If you are considering any rollback path below `7.3.0-beta.1`, also see the [7.2.4 release notes](/unraid-os/release-notes/7.2.4/).
 
-## Changes vs. 7.3.0-beta.1
-
-### Containers / Docker
-
-- Fix: Preserve user-defined container MAC addresses across Docker restart and system reboot when `--mac-address=` is set on the primary network. This fixes the beta.1 regression that caused routers and monitoring tools to see duplicate or random replacement MAC addresses after every restart. See the [user report](https://product.unraid.net/p/7-3-0-beta-1-containers-start-with-random-mac).
-- Fix: Hide stale dead or uninspectable "phantom" containers that became newly visible after the Docker 27 → 29 upgrade path. This filters confusing leftovers out of the WebGUI without mutating Docker state. Background: [Docker 29 release notes](https://docs.docker.com/engine/release-notes/29/).
-- Fix: Add the missing support needed for Strix Point iGPU Docker workloads on affected systems. See the [user report](https://product.unraid.net/p/strix-point-igpu-support).
-
-### Storage
-
-- New: Add dedicated boot pool support as a distinct option from split boot pools.
-- Fix: Address sector-size compatibility regressions for 4Kn devices and some LSI HBA setups using 512e disks that affect XFS-formatted array disks.
-- Fix: 4Kn devices formatted XFS with 7.3.0-beta.1 or newer can now be moved out of the array and mounted normally in pools or other Linux systems. Older XFS filesystems that were formatted inside the array on 4Kn disks in previous Unraid releases still cannot be corrected without reformatting.
-- Fix: Make encrypted pools using `luks:zfs` or `luks:btrfs` report normal pool status instead of showing `UNKNOWN`.
-- Fix: Update `nfs-utils` to eliminate the boot-time `nfsrahead` abort spam seen on affected systems.
-- Fix: Restore read and write totals for array devices so per-disk counters update correctly again.
-- Fix: Correct the New Config tool so it handles boot pools properly.
-
-### WebGUI / System
-
-- Improvement: Move the Onboarding Wizard under Tools and add a direct internal-boot device link when setup still needs attention.
-- Fix: Restore the Boot page browse icon on affected systems.
-- Fix: Correct black-theme dropdown visibility in the Onboarding Wizard.
-- Fix: Correct the GMT time zone selection state in the Onboarding Wizard.
-- Fix: Restore the `Bind selected to vfio` action in System Devices on affected setups.
-- Fix: Stop WebGUI and API requests from spinning up the full HDD array on affected systems.
-- Fix: Restore CPU isolation saving so selected cores apply correctly again.
-- Fix: Persist the built-in `rclone` configuration in a persistent location across reboot.
-- Fix: Re-add the ReiserFS upgrade block in `unRAIDServer.plg` so unsupported systems are prevented from updating.
-- Fix: Allow pools that were previously configured as boot pools to be removed correctly.
-
-### Unraid API
-
-- `dynamix.unraid.net` 4.32.0 - [see changes](https://github.com/unraid/api/releases)
-
-### Platform updates carried into beta.2
-
-- Improvement: The 7.3 prerelease line has been rebased from the previous public `7.3.0-beta.1` baseline through later `beta.1.x` builds, including a kernel update to `6.18.20-Unraid`, Docker `29.3.1`, ZFS `2.4.1_6.18.20_Unraid`, and an intermediate `dynamix.unraid.net` update to `4.31.1-126` before the later `4.32.0` bump above.
-- Improvement: Update kernel config for additional AMD XDNA and ACP support, including `CONFIG_DRM_ACCEL_AMDXDNA`, `CONFIG_DRM_AMD_ACP`, `CONFIG_REMOTEPROC`, generic power-domain support, and `CONFIG_REMOTEPROC_CDEV`.
-- Improvement: Add new AMD NPU firmware, Intel Bluetooth firmware, Intel wireless firmware, and the `amdxdna` kernel module in the rebased prerelease builds.
-- Improvement: Refresh bundled packages from the original public `beta.1` baseline, including updates to `bind`, `btrfs-progs`, `docker`, `glib2`, `gtk+3`, `mesa`, `nfs-utils`, `xfsprogs`, and related libraries and tooling.
-- Security: Pick up fixes for multiple `bind` and `libpng` CVEs in the rebased prerelease packages.
-
-## Full beta.1 changelog retained during the prerelease cycle
-
-The public beta.1 changelog is retained below for broader 7.3 context while the prerelease cycle is still active, especially the earlier onboarding and licensing changes that still matter during prerelease.
-
 ## Changes vs. [7.2.4](/unraid-os/release-notes/7.2.4/)
+
+### Security
+
+Update `bind` and `libpng` to fix outstanding CVEs
+
 
 ### Onboarding and internal boot
 
-New users automatically start in the onboarding wizard, where they choose language, time zone, theme, and activation code settings before selecting a boot option, including internal boot.
+New users automatically start in the onboarding wizard, where they choose language, time zone, theme, activation code settings, and boot option, including internal boot.
 
 Existing users can go to **_Settings → Onboarding Wizard_** to review settings and migrate to internal boot.
 
 For details, see [Onboarding](/unraid-os/getting-started/set-up-unraid/deploy-and-configure-unraid-os/).
+
+- New: Add dedicated boot pool support as a distinct option from split boot pools.
+- Improvement: Move the Onboarding Wizard under Tools and add a direct internal-boot device link when setup still needs attention.
+- Improvement: Update many user-facing strings from "Flash" to "Boot".
+- Improvement: Improve organization of boot-related settings.
+- Fix: Force the expected reboot or shutdown flow after internal boot setup.
+- Fix: Restore the Boot page browse icon on affected systems.
+- Fix: Correct black-theme dropdown visibility in the Onboarding Wizard.
+- Fix: Correct the GMT time zone selection state in the Onboarding Wizard.
+- Fix: Correct the New Config tool so it handles boot pools properly.
+- Fix: Allow pools that were previously configured as boot pools to be removed correctly.
+- Fix: Keep the boot pool visible when an expected boot-pool disk is missing or a wrong disk is selected.
 
 ### Licensing
 
@@ -88,198 +62,112 @@ All new and replacement keys use TPM-based licensing when possible because it is
 
 To proactively switch to TPM-based licensing, see [How can I move from flash-based licensing to TPM-based licensing](/unraid-os/troubleshooting/tpm-licensing-faq/#tpm).
 
-#### Other licensing
+- Improvement: Improve handling of missing key file states.
 
-- Improvement: Improve handling of missing key file states
+### Containers / Docker
+
+**Important: Docker has been updated from v27 (in 7.2.4) to v29. This changes how MAC addresses are allocated to containers and randomizes them.
+**
+
+- Improvement: Update Docker to `29.3.1`.
+- New: Add an optional fixed MAC address field to Docker templates for containers that need a stable network identity across restarts, including DHCP reservations, router or firewall rules, switch ACLs, and monitoring.
+- Improvement: Show Docker container MAC addresses in Advanced View alongside existing network and IP information.
+- Fix: Preserve fixed Docker MAC addresses across container restart, Docker restart, host reboot, container recreation, and delete/re-add from the saved template on supported bridge and custom networks.
+- Fix: Migrate legacy `--mac-address=` values from Extra Parameters into the new fixed MAC field where safe, while leaving templates unchanged when networking is still owned by Extra Parameters.
+- Fix: Prevent duplicate Docker user templates when container names and template filenames differ only by case on case-sensitive boot storage, such as ZFS internal boot.
+- Fix: Hide stale dead or uninspectable "phantom" containers that became newly visible after the Docker 27 to 29 upgrade path. This filters confusing leftovers out of the WebGUI without mutating Docker state. Background: [Docker 29 release notes](https://docs.docker.com/engine/release-notes/29/).
+- Fix: Add the missing support needed for Strix Point iGPU Docker workloads on affected systems. See the [user report](https://product.unraid.net/p/strix-point-igpu-support).
+- Fix: Prevent VMs created from user-defined templates from inheriting the source VM MAC address.
 
 ### Storage
 
-- New: Show corrupted files in ZFS pool status
-- New: Add user-facing control for ZFS ARC max size on **_Settings → Disk Settings → Tunable (zfs_arc_max)_**
-- Improvement: Improve visibility into pool and drive health information
-- Improvement: Improve duplicate drive detection and related messaging
-- Fix: Resolve formatting-related crashes and segfaults in affected array and boot-pool scenarios
-- Fix: Prevent drives from spinning down during parity copy as part of parity swap
-- Fix: Correct mover availability when emptying an array disk with no pool assigned
-- Fix: Correct ZFS pools waking once every 24 hours in affected cases
+- New: Show corrupted files in ZFS pool status.
+- New: Add user-facing control for ZFS ARC max size on **_Settings → Disk Settings → Tunable (zfs_arc_max)_**. This used to be controlled through a custom ZFS driver parameter. You may need to migrate your setting to the new location.
+- Improvement: Improve visibility into pool and drive health information.
+- Improvement: Improve duplicate drive detection and related messaging.
+- Fix: Address sector-size compatibility regressions for 4Kn devices and some LSI HBA setups using 512e disks that affect XFS-formatted array disks.
+- Fix: 4Kn devices formatted XFS with 7.3.0-beta.1 or newer can now be moved out of the array and mounted normally in pools or other Linux systems. Older XFS filesystems that were formatted inside the array on 4Kn disks in previous Unraid releases still cannot be corrected without reformatting.
+- Fix: Prevent drives from spinning down during parity copy as part of parity swap.
+- Fix: Correct mover availability when emptying an array disk with no pool assigned.
+- Fix: Correct ZFS pools waking once every 24 hours in affected cases.
+- Fix: Correct pool-device detection for larger device names, including devices such as `sdp` and `sdap`, so affected pool disks no longer appear as `Unknown`.
 
-### WebGUI
+### WebGUI / System
 
-- Improvement: Update many user-facing strings from “Flash” to “Boot”
-- Improvement: Improve organization of boot-related settings
-- Fix: Correct RAM display parsing after dmidecode unit label changes
-- Fix: Correct time zone label and identifier issues in affected regions
-- Fix: Correct Docker page tab behavior regression
-- Fix: Correct Docker port mapping display for localhost-only bindings
-- Fix: Correct strict proxy connectivity checks when using HTTP proxies that block CONNECT on port 80
-- Fix: Correct rc.crond status typo
-- Fix: Auto-restart SSH daemon after network recovery
-- Fix: Correct Discord notification formatting issues
-- Fix: Correct interface parsing when `ip addr` output includes peer information
+- Improvement: Refresh WebGUI and system-device workflows for the 7.3 internal-boot and hardware-support work.
+- Improvement: Add support for the Cooler Master Qube 500 case model.
+- Fix: Handle CRLF line endings in Syslinux and GRUB configuration files so the Boot Parameters page can read settings edited from Windows.
+- Fix: Correct File Manager styling on the Main tab so it follows the selected theme.
+- Fix: Correct RAM display parsing after dmidecode unit label changes.
+- Fix: Correct time zone label and identifier issues in affected regions.
+- Fix: Restore the `Bind selected to vfio` action in System Devices on affected setups.
+- Fix: Stop WebGUI and API requests from spinning up the full HDD array on affected systems.
+- Fix: Restore CPU isolation saving so selected cores apply correctly again.
+- Fix: Persist the built-in `rclone` configuration in a persistent location across reboot.
+- Fix: Correct strict proxy connectivity checks when using HTTP proxies that block CONNECT on port 80.
+- Fix: Correct rc.crond status typo.
+- Fix: Auto-restart SSH daemon after network recovery.
+- Fix: Correct Discord notification formatting issues.
+- Fix: Correct interface parsing when `ip addr` output includes peer information.
+- Fix: Correct custom image case model handling on the login page.
+- Fix: Remove outdated ReiserFS warnings and stale references.
 
 ### File Manager
 
-- Improvement: Improve File Manager UI and overall performance
-- Improvement: Improve same-filesystem move operations
-- Improvement: Improve upload behavior
-- Fix: Correct path handling issues involving `/sub/` in file paths
-- Fix: Correct scrollbar interaction issues during copy or move operations
-- Fix: Correct handling of double quotes in directory names
-- Fix: Correct move and rename edge cases
-- Fix: Preserve empty directories during affected rename operations
+- Improvement: Improve File Manager UI and overall performance.
+- Improvement: Improve same-filesystem move operations.
+- Improvement: Improve upload behavior.
+- Fix: Correct path handling issues involving `/sub/` in file paths.
+- Fix: Correct scrollbar interaction issues during copy or move operations.
+- Fix: Correct handling of double quotes in directory names.
+- Fix: Correct move and rename edge cases.
+- Fix: Preserve empty directories during affected rename operations.
+
+### Networking / Hardware
+
+- Improvement: Update kernel config for additional AMD XDNA and ACP support, including `CONFIG_DRM_ACCEL_AMDXDNA`, `CONFIG_DRM_AMD_ACP`, `CONFIG_REMOTEPROC`, generic power-domain support, and `CONFIG_REMOTEPROC_CDEV`.
+- Improvement: Add AMD NPU firmware, Intel Bluetooth firmware, Intel wireless firmware, and the `amdxdna` kernel module.
+- New: Add **_Settings → Tailscale_** stub page for easier plugin discovery.
 
 ### Virtualization
 
-- Improvement: Improve System Devices visibility and VM template workflows
-- Improvement: Improve custom VNC port validation and defaults
-- Fix: Prevent VMs created from user-defined templates from inheriting the source VM MAC address
-- Fix: Correct VM snapshot commit cleanup not updating snapshot metadata correctly
-- Fix: Correct libvirt startup issues encountered during testing
-
-## Misc
-
-- New: Add **_Settings → Tailscale_** stub page for easier plugin discovery
-- Fix: Correct custom image case model handling on the login page
-- Fix: Remove outdated ReiserFS warnings and stale references
+- Improvement: Improve System Devices visibility and VM template workflows.
+- Improvement: Improve custom VNC port validation and defaults.
+- Improvement: Update QEMU to `10.2.2`, libvirt to `12.2.0`, and refresh the OVMF firmware package.
+- Fix: Address virtiofs hangs seen with affected Linux guests.
+- Fix: Correct VM snapshot commit cleanup not updating snapshot metadata correctly.
+- Fix: Correct libvirt startup issues encountered during testing.
 
 ### Unraid API
 
-- dynamix.unraid.net 4.30.1 - [see changes](https://github.com/unraid/api/releases)
+- `dynamix.unraid.net` 4.32.3 - [see changes](https://github.com/unraid/api/releases)
 
 ### Linux kernel
 
-- version 6.18.18-Unraid
+- Linux kernel: version `6.18.23-Unraid`
 
 ### Base distro updates
 
-- aaa_libraries: version 15.1
-- at-spi2-core: version 2.58.3
-- bash: version 5.3.009
-- bash-completion: version 2.17.0
 - bind: version 9.20.20
-- brotli: version 1.2.0
 - btrfs-progs: version 6.19
-- ca-certificates: version 20260212
-- cifs-utils: version 7.5
-- coreutils: version 9.10
-- cryptsetup: version 2.8.4
-- curl: version 8.18.0
-- dmidecode: version 3.7
-- dnsmasq: version 2.92
-- docker: version 29.3.0-x86_64-1_LT
-- dynamix.unraid.net: version 4.30.1
-- efibootmgr: version 18
-- efivar: version 20201015_cff88dd
-- elfutils: version 0.194
-- elogind: version 255.22
-- etc: version 15.1
-- ethtool: version 6.19
-- exfatprogs: version 1.3.1
-- file: version 5.47
-- freeglut: version 3.8.0
-- freetype: version 2.14.2
-- gawk: version 5.4.0
-- gdk-pixbuf2: version 2.44.5
-- gettext: version 1.0
-- gettext-tools: version 1.0
-- git: version 2.53.0
-- glew: version 2.3.1
+- docker: version 29.3.1
 - glib2: version 2.86.4
-- glibc-zoneinfo: version 2026a
-- gnutls: version 3.8.12
-- grub: version 2.14
-- harfbuzz: version 13.0.0
-- icu4c: version 78.2
-- iotop-c: version 1.30
-- iperf3: version 3.20
-- iproute2: version 6.19.0
-- iptables: version 1.8.13
-- jansson: version 2.15.0
-- krb5: version 1.22.2
-- less: version 692
-- libarchive: version 3.8.5
-- libcap-ng: version 0.9.1
-- libdeflate: version 1.25
-- libdisplay-info: version 0.3.0
-- libdrm: version 2.4.131
-- libevdev: version 1.13.6
-- libfontenc: version 1.1.9
-- libgcrypt: version 1.12.1
-- libgpg-error: version 1.59
-- libjpeg-turbo: version 3.1.3
-- libnetfilter_conntrack: version 1.1.1
-- libnftnl: version 1.3.1
-- libnl3: version 3.12.0
-- libnvme: version 1.16.1
-- libpcap: version 1.10.6
-- libpng: version 1.6.55
-- libtasn1: version 4.21.0
-- libunistring: version 1.4.2
-- liburing: version 2.14
-- libvirt: version 11.10.0-x86_64-1cf_LT
-- libvirt-php: version 0.5.8_abf2ec0-x86_64-1_LT
-- libX11: version 1.8.13
-- libx86: version 1.1.1
-- libXcomposite: version 0.4.7
-- libXdamage: version 1.1.7
-- libXext: version 1.3.7
-- libXinerama: version 1.1.6
-- libxkbcommon: version 1.13.1
-- libxkbfile: version 1.2.0
-- libxml2: version 2.15.2
-- libXmu: version 1.3.1
-- libXpm: version 3.5.18
-- libXrandr: version 1.5.5
-- libxslt: version 1.1.45
-- libXxf86dga: version 1.1.7
-- libXxf86vm: version 1.1.7
-- lmdb: version 0.9.35
-- lsof: version 4.99.6
-- lvm2: version 2.03.38
-- mcelog: version 210
+- gtk+3: version 3.24.51
+- libvirt: version 12.2.0
 - mesa: version 26.0.1
-- nano: version 8.7.1
-- ncurses: version 6.6
 - nfs-utils: version 2.8.5
-- nghttp2: version 1.68.0
-- nghttp3: version 1.15.0
-- noto-fonts-ttf: version 2026.03.01
-- ntp: version 4.2.8p18
-- nvme-cli: version 2.16
-- openssl: version 3.5.5
-- ovmf-stable: version 202508
-- p11-kit: version 0.26.2
-- pam: version 1.7.2
-- pango: version 1.57.0
-- pcre2: version 10.47
-- php: version 8.4.15-x86_64-1_LT
-- pkgtools: version 15.1
-- procps-ng: version 4.0.6
-- qemu: version 10.1.2-x86_64-1cf_LT
-- rclone: version 1.72.0-x86_64-1_SBo_LT
-- readline: version 8.3.003
-- shadow: version 4.19.4
-- spirv-llvm-translator: version 20260218_56778655
-- sqlite: version 3.51.2
-- sysstat: version 12.7.9
-- talloc: version 2.4.4
-- tdb: version 1.4.15
-- telnet: version 0.17
-- tpm2-tools: version 5.7
-- tpm2-tss: version 4.1.3
-- userspace-rcu: version 0.15.6
-- util-linux: version 2.41.3
-- virglrenderer: version 1.2.0
-- virtiofsd: version 1.13.2
-- wireguard-tools: version 1.0.20260223
-- wireless-regdb: version 2026.02.04
-- xauth: version 1.1.5
+- qemu: version 10.2.2
 - xfsprogs: version 6.18.0
-- xkbcomp: version 1.5.0
-- xkeyboard-config: version 2.47
-- xkill: version 1.0.7
-- xorg-server: version 21.1.21
-- xterm: version 407
-- xz: version 5.8.2
-- zfs: version 2.4.1_6.18.18_Unraid-x86_64-1_LT
-- zlib: version 1.3.2
+- zfs: version 2.4.1
+
+## Prerelease tester notes
+
+### CHANGES FROM BETA.2
+
+- Docker template MAC handling now has a dedicated fixed MAC field and shows live MAC addresses in Advanced View.
+- Docker template lookup now handles case-only filename differences on case-sensitive boot storage.
+- Boot pool and pool-device display fixes for missing, wrong, or larger device names.
+- CRLF handling for Syslinux and GRUB configuration files.
+- File Manager theme fix on the Main tab.
+- QEMU `10.2.2`, libvirt `12.2.0`, refreshed OVMF firmware, and a virtiofs hang fix.
+- `dynamix.unraid.net` `4.32.3`.

--- a/docs/unraid-os/release-notes/7.3.0.md
+++ b/docs/unraid-os/release-notes/7.3.0.md
@@ -71,7 +71,6 @@ To proactively switch to TPM-based licensing, see [How can I move from flash-bas
 - Improvement: Update Docker to `29.3.1`.
 - New: Add an optional fixed MAC address field to Docker templates for containers that need a stable network identity across restarts, including DHCP reservations, router or firewall rules, switch ACLs, and monitoring.
 - Improvement: Show Docker container MAC addresses in Advanced View alongside existing network and IP information.
-- Fix: Preserve fixed Docker MAC addresses across container restart, Docker restart, host reboot, container recreation, and delete/re-add from the saved template on supported bridge and custom networks.
 - Fix: Migrate legacy `--mac-address=` values from Extra Parameters into the new fixed MAC field where safe, while leaving templates unchanged when networking is still owned by Extra Parameters.
 - Fix: Prevent duplicate Docker user templates when container names and template filenames differ only by case on case-sensitive boot storage, such as ZFS internal boot.
 - Fix: Hide stale dead or uninspectable "phantom" containers that became newly visible after the Docker 27 to 29 upgrade path. This filters confusing leftovers out of the WebGUI without mutating Docker state. Background: [Docker 29 release notes](https://docs.docker.com/engine/release-notes/29/).

--- a/docs/unraid-os/release-notes/7.3.0.md
+++ b/docs/unraid-os/release-notes/7.3.0.md
@@ -33,8 +33,7 @@ If you are considering any rollback path below `7.3.0-beta.1`, also see the [7.2
 
 ### Security
 
-Update `bind` and `libpng` to fix outstanding CVEs
-
+Update `bind` to fix outstanding CVEs.
 
 ### Onboarding and internal boot
 


### PR DESCRIPTION
## Summary

- Update the 7.3.0 release notes from the beta.2 draft to the rc.1 draft.
- Reframe the changelog for users upgrading from 7.2.4.
- Add the less-prominent CHANGES FROM BETA.2 section and individual base distro package entries.

## Why

The existing page still reflected the beta.2 release-note structure. The rc.1 notes need to describe the full 7.3.0 surface area, including onboarding/internal boot, Docker and storage changes, hardware support, virtualization updates, API/kernel updates, and package refreshes.

## Validation

- `git diff --check -- docs/unraid-os/release-notes/7.3.0.md`
- `pnpm exec remark docs/unraid-os/release-notes/7.3.0.md --quiet --frail`

Per repo guidance, I did not run the full docs build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated 7.3.0 release notes to RC.1, reorganized changelog baseline to 7.2.4, and added "Prerelease tester notes".
* **New Features**
  * Onboarding/internal-boot workflow improvements and automatic onboarding start for new installs.
* **Bug Fixes**
  * Docker v29: MAC handling changes, migration of legacy MACs, live MAC display, and phantom container fixes.
  * Storage: ZFS ARC control, 4Kn/XFS compatibility, pool/device detection, mover/parity-swap fixes.
* **Platform & Security**
  * Kernel, virtualization, firmware and package bumps plus CVE fixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->