### PR TITLE
docs(connect): align remote access guide with current UI

### DIFF
--- a/docs/unraid-connect/overview-and-setup.mdx
+++ b/docs/unraid-connect/overview-and-setup.mdx
@@ -21,7 +21,7 @@ With Unraid Connect, you can:
 - Monitor real-time server health and resource usage, including storage, network, and Docker container status.
 - Perform and schedule secure online flash backups to protect your configuration and licensing information.
 - Receive notifications about server health, storage status, and critical events.
-- Use dynamic remote access and server deep linking to navigate to specific management pages or troubleshoot issues quickly.
+- Use remote access links and server deep linking to navigate to specific management pages or troubleshoot issues quickly.
 - Manage multiple servers from a single dashboard, making it perfect for users with more than one Unraid system.
 
 Unraid Connect is more than just an add-on; it's an essential extension of the Unraid platform, designed to maximize the value, security, and convenience of your Unraid OS investment.

--- a/docs/unraid-connect/overview-and-setup.mdx
+++ b/docs/unraid-connect/overview-and-setup.mdx
@@ -17,10 +17,11 @@ Unraid Connect works seamlessly with Unraid OS, boosting your server experience 
 
 With Unraid Connect, you can:
 
-- Remotely access and manage your Unraid server from any device, anywhere in the world.
+- Monitor your server and manage supported Connect features from any device, anywhere in the world.
 - Monitor real-time server health and resource usage, including storage, network, and Docker container status.
 - Perform and schedule secure online flash backups to protect your configuration and licensing information.
 - Receive notifications about server health, storage status, and critical events.
+- Manage supported server actions through the Connect dashboard without exposing the full %%WebGUI|web-gui%% to the internet.
 - Use remote access links and server deep linking to navigate to specific management pages or troubleshoot issues quickly.
 - Manage multiple servers from a single dashboard, making it perfect for users with more than one Unraid system.
 
@@ -114,16 +115,19 @@ When you click **Details** on a server, you will see:
 
 :::tip
 
-To use all management features, provision a myunraid.net certificate under ***Settings → Management Access*** on your server.
+For full remote administration, prefer the official [%%Tailscale|tailscale%% integration](../unraid-os/system-administration/secure-your-server/tailscale.mdx). It gives you private remote access to the %%WebGUI|web-gui%% and services without exposing them to the public internet.
 
 :::
 
-With a valid **myunraid.net** certificate, Unraid Connect enables secure, remote server management directly from the Connect web interface.
+Signing in to Unraid Connect gives you secure dashboard access without exposing the %%WebGUI|web-gui%% directly to the internet. The server maintains a secure outbound connection that enables supported Connect features with restricted API access.
+
+If you also enable **Unraid Connect Remote Access**, that separate feature exposes the full %%WebGUI|web-gui%% through WAN port forwarding or %%UPnP|upnp%%. Use it only when you specifically need public browser access to the %%WebGUI|web-gui%%.
 
 Remote management features include:
 
-- **Remote WebGUI access:** Access the %%WebGUI|web-gui%% from anywhere.
-- **Array controls:** Start or stop %%array|array%%s and manage storage pools.
+- **Dashboard-based management:** Use supported Connect controls without opening the full %%WebGUI|web-gui%% to the internet.
+- **Optional Remote WebGUI access:** Access the full %%WebGUI|web-gui%% from anywhere if you separately enable Unraid Connect Remote Access.
+- **Array controls:** Start or stop %%array|array%%s and manage storage pools through supported Connect actions.
 - **Docker and VM management:** View, start, stop, and monitor containers and %%VM|vm%%s.
 - **Parity & Scrub:** Launch %%parity check|parity-check%% or %%ZFS|zfs%%/%%BTRFS|btrfs%% scrub jobs
 - **Flash backup:** Trigger and monitor flash device backups to the cloud.

--- a/docs/unraid-connect/remote-access.mdx
+++ b/docs/unraid-connect/remote-access.mdx
@@ -3,14 +3,9 @@ sidebar_position: 3
 sidebar_label: Remote access
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-import RemoteAccessDynamic from './partials/remote-access/dynamic.mdx';
-import RemoteAccessStatic from './partials/remote-access/static.mdx';
-
 # Remote access
 
-Unlock secure, browser-based access to your Unraid %%WebGUI|web-gui%% from anywhere with remote access. This feature is ideal for managing your server when you're away from home - no complicated networking or %%VPN Tunnel|vpn-tunnel%% setup is required. For more advanced needs, such as connecting to Docker containers or accessing network drives, a %%VPN Tunnel|vpn-tunnel%% remains the recommended solution.
+Unlock secure, browser-based access to your Unraid %%WebGUI|web-gui%% from anywhere with remote access. This feature is ideal for managing your server when you're away from home, but it does require either %%UPnP|upnp%% or a manual port forwarding rule on your router. For more advanced needs, such as connecting to Docker containers or accessing network drives, a %%VPN Tunnel|vpn-tunnel%% remains the recommended solution.
 
 :::important[Security reminder]
 
@@ -20,9 +15,9 @@ Before enabling remote access, ensure your root password is strong and unique. U
 
 Remote access through Unraid Connect provides:
 
-- **Convenience** - Quickly access your server’s management interface from anywhere, using a secure, cloud-managed connection.
-- **Security** - Dynamic access modes limit exposure by only allowing access to the internet when necessary, which helps reduce risks from automated attacks.
-- **Simplicity** - No need for manual port forwarding or VPN client setup for basic management tasks.
+- **Convenience** - Quickly access your server’s management interface from anywhere, using a trusted Unraid Connect URL.
+- **Security** - Your %%WebGUI|web-gui%% traffic is encrypted when SSL/TLS is configured correctly.
+- **Simplicity** - %%UPnP|upnp%% can create the required port mapping automatically when your router supports it.
 
 :::tip
 
@@ -45,45 +40,32 @@ Your Unraid server will be ready to accept secure remote connections via the %%W
 
 ---
 
-## Choosing a remote access type
+## Choosing a remote access configuration
 
-Unraid Connect offers two modes:
+In current Unraid 7.2.x releases, the Unraid API settings page exposes these remote access controls:
 
-<Tabs>
-  <TabItem value="dynamic" label="Dynamic remote access" default>
-    <RemoteAccessDynamic />
-  </TabItem>
+- **Allow Remote Access** - Choose whether remote access is **Disabled** or **Always** available.
+- **Remote Access Forward Type** - Choose **Static** for manual port forwarding, or **UPnP** to let your router create the port mapping automatically.
+- **Remote Access WAN Port** - Choose the WAN port to forward when using **Static** forwarding.
 
-  <TabItem value="static" label="Static remote access">
-    <RemoteAccessStatic />
-  </TabItem>
-</Tabs>
+When remote access is set to **Always**, your %%WebGUI|web-gui%% is continuously reachable from the internet on the configured WAN port. Use a strong root password, keep Unraid OS updated, and disable remote access when you do not need it.
 
-| Feature                              | Dynamic remote access       | Static remote access      |
-| ------------------------------------ | --------------------------- | ------------------------- |
-| %%WebGUI\|web-gui%% open to internet | Only when enabled           | Always                    |
-| Attack surface                       | Minimized                   | Maximized                 |
-| Automation                           | Auto open/close via Connect | Manual setup, always open |
-| %%UPnP\|upnp%% support               | Yes                         | Yes                       |
-|                                      | **Recommended for most**    |                           |
+Dynamic, on-demand remote access is not currently exposed in the Unraid API settings page. If you need remote management without keeping the %%WebGUI|web-gui%% exposed through port forwarding, use [Tailscale](../unraid-os/system-administration/secure-your-server/tailscale.mdx) or another %%VPN Tunnel|vpn-tunnel%%.
 
-## Dynamic remote access setup
+## Enable remote access
 
-To set up dynamic remote access:
+To enable remote access:
 
-1. In ***Settings → Management Access → Unraid API***, select a dynamic option from the Remote Access dropdown:
-   - **Dynamic - UPnP:** Uses %%UPnP|upnp%% to open and close a random port automatically (requires %%UPnP|upnp%% enabled on your router).
-   - **Dynamic - Manual port forward:** Requires you to forward the selected port on your router manually.
+1. In the Unraid %%WebGUI|web-gui%%, navigate to ***Settings → Management Access*** and open the **Unraid API Settings** tab.
+2. Set **Allow Remote Access** to **Always**.
+3. Choose a **Remote Access Forward Type**:
+   - **UPnP:** Lets Unraid ask your router to create the WAN port mapping automatically. This requires %%UPnP|upnp%% support and %%UPnP|upnp%% enabled on your router.
+   - **Static:** Requires you to create the port forwarding rule manually on your router.
+4. If you choose **Static**, enter the **Remote Access WAN Port** you want to use.
+5. Click **Apply**.
+6. Log in to [Unraid Connect](https://connect.myunraid.net/) and click the **Manage** link to connect to your server remotely.
 
-2. Navigate to [Unraid Connect](https://connect.myunraid.net/), and go to the management or server details page.
-
-3. The **Dynamic remote access** card will show a button if your server isn’t currently accessible from your location.
-
-4. Click the button to enable WAN access. If using %%UPnP|upnp%%, a new port forward lease is created (typically for 30 minutes) and auto-renewed while active.
-
-5. The card will display the current status and %%UPnP|upnp%% state.
-
-6. After 10 minutes of inactivity - or if you click **Disable remote access** - internet access is automatically revoked. %%UPnP|upnp%% leases are removed as well.
+If the **Manage** link does not work, use the relevant forwarding section below to verify that the WAN port reaches your server's HTTPS port.
 
 ---
 
@@ -100,12 +82,10 @@ To configure %%UPnP|upnp%%:
    Navigate to ***Settings → Management Access*** and change **Use %%UPnP|upnp%%** to **Yes**.
 
 3. **Select %%UPnP|upnp%% in Unraid Connect.**
-   On the Unraid Connect settings page, choose the remote access option as %%UPnP|upnp%% (select either Dynamic or Always On) and then click **Apply**.
+   On the Unraid API settings page, set **Allow Remote Access** to **Always**, set **Remote Access Forward Type** to **UPnP**, and then click **Apply**.
 
-4. **Verify port forwarding (Always On only).**
+4. **Verify port forwarding.**
    Click the **Check** button. If successful, you'll see the message, "Your Unraid Server is reachable from the Internet."
-
-   For Dynamic forwarding, you need to click **Enable Dynamic Remote Access** in [Unraid Connect](https://connect.myunraid.net/) to allow access.
 
 :::caution[Troubleshooting]
 
@@ -129,9 +109,7 @@ To configure manual port forwarding:
 
    Some routers may require the WAN port and HTTPS port to match. If so, use the same high random number for both.
 
-4. **Verify port forwarding (Always On only):** Press the **Check** button. If everything is correct, you’ll see “Your Unraid Server is reachable from the Internet.”
-
-   For dynamic forwarding, ensure to click **Enable Dynamic Remote Access** in [Unraid Connect](https://connect.myunraid.net/) to enable access.
+4. **Verify port forwarding:** Press the **Check** button. If everything is correct, you’ll see “Your Unraid Server is reachable from the Internet.”
 
 5. **Access your server:** Log in to [Unraid Connect](https://connect.myunraid.net/) and click the **Manage** link to connect to your server remotely.
 

--- a/docs/unraid-connect/remote-access.mdx
+++ b/docs/unraid-connect/remote-access.mdx
@@ -5,11 +5,17 @@ sidebar_label: Remote access
 
 # Remote access
 
-Unlock secure, browser-based access to your Unraid %%WebGUI|web-gui%% from anywhere with remote access. This feature is ideal for managing your server when you're away from home, but it does require either %%UPnP|upnp%% or a manual port forwarding rule on your router. For more advanced needs, such as connecting to Docker containers or accessing network drives, a %%VPN Tunnel|vpn-tunnel%% remains the recommended solution.
+This page covers **Unraid Connect Remote Access**, which publishes your %%WebGUI|web-gui%% to the internet by using either %%UPnP|upnp%% or a manual port forwarding rule on your router. If you want full remote management without exposing the %%WebGUI|web-gui%% to WAN traffic, prefer the official [%%Tailscale|tailscale%% integration](../unraid-os/system-administration/secure-your-server/tailscale.mdx). For more advanced needs, such as connecting to Docker containers or accessing network drives, a %%VPN Tunnel|vpn-tunnel%% remains the recommended solution.
 
 :::important[Security reminder]
 
 Before enabling remote access, ensure your root password is strong and unique. Update it on the **Users** page if required. Additionally, keep your Unraid OS updated to the latest version to protect against security vulnerabilities. [Learn more about updating Unraid here](../unraid-os/system-administration/maintain-and-update/upgrading-unraid.mdx).
+
+:::
+
+:::note[Connect dashboard access is different]
+
+Signing in to the [Unraid Connect dashboard](https://connect.myunraid.net/) does **not** by itself expose your %%WebGUI|web-gui%% to the internet. Dashboard access uses a server-initiated connection with restricted API access for supported Connect features. **Unraid Connect Remote Access** is a separate feature that exposes the full %%WebGUI|web-gui%% through WAN port forwarding or %%UPnP|upnp%%.
 
 :::
 
@@ -19,9 +25,9 @@ Remote access through Unraid Connect provides:
 - **Security** - Your %%WebGUI|web-gui%% traffic is encrypted when SSL/TLS is configured correctly.
 - **Simplicity** - %%UPnP|upnp%% can create the required port mapping automatically when your router supports it.
 
-:::tip
+:::tip[Preferred approach]
 
-For full network access or advanced use cases, consider setting up [Tailscale](../unraid-os/system-administration/secure-your-server/tailscale.mdx) or a VPN solution.
+For most users, the official [%%Tailscale|tailscale%% integration](../unraid-os/system-administration/secure-your-server/tailscale.mdx) is the better choice for remote administration because it avoids exposing the %%WebGUI|web-gui%% to the public internet. Use Unraid Connect Remote Access only when you specifically need browser access to the public-facing %%WebGUI|web-gui%% URL.
 
 :::
 
@@ -48,9 +54,9 @@ In current Unraid 7.2.x releases, the Unraid API settings page exposes these rem
 - **Remote Access Forward Type** - Choose **Static** for manual port forwarding, or **UPnP** to let your router create the port mapping automatically.
 - **Remote Access WAN Port** - Choose the WAN port to forward when using **Static** forwarding.
 
-When remote access is set to **Always**, your %%WebGUI|web-gui%% is continuously reachable from the internet on the configured WAN port. Use a strong root password, keep Unraid OS updated, and disable remote access when you do not need it.
+When remote access is set to **Always**, your %%WebGUI|web-gui%% is continuously reachable from the internet on the configured WAN port. Both **Static** and **UPnP** remote access publish the %%WebGUI|web-gui%% to WAN traffic. Use a strong root password, keep Unraid OS updated, and disable remote access when you do not need it.
 
-Dynamic, on-demand remote access is not currently exposed in the Unraid API settings page. If you need remote management without keeping the %%WebGUI|web-gui%% exposed through port forwarding, use [Tailscale](../unraid-os/system-administration/secure-your-server/tailscale.mdx) or another %%VPN Tunnel|vpn-tunnel%%.
+Dynamic, on-demand remote access is not currently exposed in the Unraid API settings page. If you need remote management without keeping the %%WebGUI|web-gui%% exposed through port forwarding, prefer [%%Tailscale|tailscale%%](../unraid-os/system-administration/secure-your-server/tailscale.mdx) or another %%VPN Tunnel|vpn-tunnel%%.
 
 ## Enable remote access
 

--- a/docs/unraid-os/system-administration/secure-your-server/security-fundamentals.mdx
+++ b/docs/unraid-os/system-administration/secure-your-server/security-fundamentals.mdx
@@ -175,7 +175,7 @@ Never expose the %%WebGUI|web-gui%% directly to the internet. Instead, use secur
 - **%%WireGuard|wireguard%% VPN** is built into Unraid and provides a secure, encrypted tunnel for remote management.
 - **%%OpenVPN|openvpn%%** is available as a plugin or Docker container.
 - Many modern routers offer built-in VPN support - check your router documentation for setup.
-- The [Unraid Connect](../../../unraid-connect/overview-and-setup.mdx) plugin enables remote access to the %%WebGUI|web-gui%%, but requires a port to be forwarded on your router.
+- Signing in to [Unraid Connect](../../../unraid-connect/overview-and-setup.mdx) allows supported dashboard management without directly exposing the %%WebGUI|web-gui%% to the internet, but the separate Unraid Connect Remote Access feature does require WAN port forwarding or %%UPnP|upnp%%. Prefer %%Tailscale|tailscale%% when you need full remote %%WebGUI|web-gui%% access.
 
 ---
 


### PR DESCRIPTION
## Summary
- update the Unraid Connect remote access guide to match the current 7.2.x settings UI
- remove dynamic remote access setup instructions that are not currently exposed
- clarify that the official Tailscale integration is the preferred option for full remote administration
- distinguish Connect dashboard sign-in from the separate Remote Access feature that exposes the WebGUI via WAN port forwarding or UPnP

## Why
A forum report showed that Unraid 7.2.4 users see `Allow Remote Access: Disabled/Always` with `Forward Type: Static/UPnP`, while the docs were still instructing them to choose dynamic modes that do not exist in the current UI.

The wording also needed a clearer security distinction: signing in to the Connect dashboard does not by itself expose the WebGUI to the internet, while Unraid Connect Remote Access does. For most users who want full remote administration, the official Tailscale integration is the better recommendation.

## Validation
- `git diff --check origin/main...HEAD`
- targeted content review of the updated docs pages

## Context
Forum thread: https://forums.unraid.net/topic/198357-unraid-connect-remote-access-settings-dont-match-guide-724/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated remote access docs for Unraid 7.2.x configuration model.
  * Clarified that signing into Connect gives dashboard management only and does not expose the full WebGUI.
  * Made explicit that full WebGUI remote access requires WAN port forwarding or UPnP and should be enabled only when needed.
  * Recommend using Tailscale for private WebGUI/services access.
  * Simplified “Enable remote access” guidance and verification steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->