### PR TITLE
[codex] Update 7.3.0 rc.2 changelog

### DIFF
--- a/docs/unraid-os/release-notes/7.3.0.md
+++ b/docs/unraid-os/release-notes/7.3.0.md
@@ -1,10 +1,8 @@
-# Version 7.3.0-rc.1 2026-04-22
+# Version 7.3.0-rc.2 2026-05-06
 
-This release candidate includes onboarding and internal boot, TPM-based licensing, Docker and storage improvements, WebGUI improvements, virtualization updates, hardware support, and platform package updates.
+This release candidate builds on 7.3.0-rc.1 with targeted fixes for internal boot, ZFS pool replacement workflows, virtualization, Docker, TPM-based licensing, WebGUI security hardening and other misc. bug fixes.
 
 This is RELEASE CANDIDATE software. Please use on test servers only.
-
-Curious about what our different release types are? See [Unraid OS release types](/unraid-os/updating-unraid/release-types/).
 
 ## Upgrading
 
@@ -15,28 +13,75 @@ For step-by-step instructions, see [Updating Unraid](/unraid-os/updating-unraid/
 See [Unraid OS Pre-release (Bugs & Feedback)](https://product.unraid.net/b/unraid-os-prerelease-bugs-feedback) for issues reported by other testers.
 
 - During internal boot setup, the WebGUI may show **Array Offline** while internal boot configures. **DO NOT** manually restart or remove your flash drive during this process.
-- Internal boot requires boot storage that can be accessed by in-tree Linux drivers during startup. Devices that require third-party drivers or post-boot configuration cannot be used for internal boot.
+- Internal boot requires boot storage that can be accessed by built-in Linux drivers during startup. Devices that require third-party drivers or post-boot configuration cannot be used for internal boot. Unraid supports the following drivers for internal boot:
+  - mvsas (rc.2)
+  - mpt3sas
+  - smartpqi (rc.2)
+  - nvme
+  - ahci
+  - mmc
+- Some invalid ZFS pool names that begin with reserved ZFS prefixes may fail without a clear WebGUI error. Choose a different pool name if creation does not complete.
+- If a split boot-pool device is removed and another device is added immediately afterward, the slot count may not always update until the server is rebooted.
 
 ### Notes
 
-- Adding, removing, and replacing devices in the ZFS boot pool generally works correctly. One exception: if you start with a dedicated boot pool made from two small devices and replace them one at a time with larger devices, the pool may convert to a split pool.
+- Adding, removing, and replacing devices in the ZFS boot pool works correctly. If you start with a dedicated boot pool made from two small devices and replace them one at a time with larger devices, the pool may convert to a split pool.
 - When boot-pool devices are added, removed, or replaced, Unraid does not currently update the server BIOS boot priority automatically. After making those changes, verify the BIOS boot order manually.
 
 ### Rolling back
 
-- If you already enabled internal boot or switched to TPM-based licensing while testing the 7.3 pre-release, you can roll back to `7.3.0-beta.1` without issue.
-- Do not roll back to `7.2.4` or earlier after enabling internal boot or TPM-based licensing.
+- If you already enabled internal boot or switched to TPM-based licensing while testing the 7.3 pre-release, you can roll back to `7.3.0-rc.1` without issue.
+- Do not roll back to `7.2.5` or earlier after enabling internal boot or TPM-based licensing.
 - If you upgrade ZFS pool features, earlier Unraid releases may not be able to import those pools.
 - If you need to roll back, follow the normal pre-release rollback process before moving between builds.
 
-If you are considering any rollback path below `7.3.0-beta.1`, also see the [7.2.4 release notes](/unraid-os/release-notes/7.2.4/).
+If you are considering any rollback path below `7.3.0-rc.1`, also see the [7.2.4 release notes](/unraid-os/release-notes/7.2.4/).
 
-## Changes vs. [7.2.4](/unraid-os/release-notes/7.2.4/)
+## Changes from rc.1
+
+Only the items in this section are new or materially updated in rc.2. The full 7.3.0-rc.1 changelog is included below.
 
 ### Security
 
-- Update `bind` to fix outstanding CVEs.
-- Update Docker to include runc fixes for CVE-2025-31133, CVE-2025-52565, and CVE-2025-52881.
+- Security: Add WebGUI security hardening for authenticated-session request handling. Upgrade recommended - this security fix is also present in 7.2.5.
+- Security note: The included 7.3 kernel already contains the fix for CVE-2026-31431, the Copy Fail local privilege escalation vulnerability. This security fix is also present in 7.2.5.
+
+### Licensing
+
+- Fix: Improve TPM-based license replacement blacklist handling so a transferred TPM-based key is blocked without permanently blocking the underlying motherboard GUID from future valid activation.
+
+### Containers / Docker
+
+- Improvement: Update Docker to version `29.4.1`.
+
+### Storage
+
+- Feat: Add mvsas and smartpqi as built-in storage drivers - this allows them to be used for internal boot
+- Fix: Address an md/unraid driver crash.
+- Fix: Correct ZFS pool replacement handling when a dropped device is marked `REMOVED`, so replacement workflows no longer leave the pool degraded with a stale blue new-device state or repeated overwrite warning.
+- Fix: Improve dedicated and split boot-pool detection after boot-pool devices are replaced with larger devices.
+- Fix: Allow adding a device to a formatted split boot pool when the data partition is formatted as ZFS or BTRFS.
+- Fix: Prevent creation of ZFS pools whose names start with reserved ZFS name prefixes: `mirror`, `raidz`, `draid`, and `spare`.
+
+### WebGUI / System
+
+- New: Show chassis serial number in System Info when a valid chassis serial is available.
+- Fix: Keep the WebGUI responsive while adding Docker containers from the Add Container page.
+- Fix: Correct stale status display after affected storage replacement workflows.
+- Fix: Use online / offline instead of on-line / off-line in various text
+
+### Virtualization
+
+- Fix: Update deprecated VM machine types during startup so older VMs do not fail with unsupported QEMU machine-type errors after upgrading.
+- Fix: Show the assigned `RenderGPU` for the first VM in the VM list when using Virtio 3D.
+
+## Changes from [7.2.5](/unraid-os/release-notes/7.2.5/) - Previously included in 7.3.0-rc.1
+
+### Security
+
+- Security: Add WebGUI security hardening for authenticated-session request handling. Upgrade recommended.
+- Security: Update `bind` from `9.20.13` to `9.20.20`.
+- Security note: The included 7.3 kernel contains the fix for CVE-2026-31431, the Copy Fail local privilege escalation vulnerability.
 
 ### Onboarding and internal boot
 
@@ -57,6 +102,7 @@ For details, see [Onboarding](/unraid-os/getting-started/set-up-unraid/deploy-an
 - Fix: Correct the New Config tool so it handles boot pools properly.
 - Fix: Allow pools that were previously configured as boot pools to be removed correctly.
 - Fix: Keep the boot pool visible when an expected boot-pool disk is missing or a wrong disk is selected.
+- Fix: Improve dedicated and split boot-pool detection after boot-pool devices are replaced with larger devices.
 
 ### Licensing
 
@@ -65,20 +111,17 @@ All new and replacement keys use TPM-based licensing when possible because it is
 To proactively switch to TPM-based licensing, see [How can I move from flash-based licensing to TPM-based licensing](/unraid-os/troubleshooting/tpm-licensing-faq/#tpm).
 
 - Improvement: Improve handling of missing key file states.
+- Fix: Improve TPM-based license replacement blacklist handling so a transferred TPM-based key is blocked without permanently blocking the underlying motherboard GUID from future valid activation.
 
 ### Containers / Docker
 
-**Important: Docker has been updated from v27 (in 7.2.4) to v29. This changes how MAC addresses are allocated to containers and randomizes them.
-**
-
-- Improvement: Update Docker to `29.3.1`.
+- Improvement: Update Docker from `29.3.1` to `29.4.1`.
 - New: Add an optional fixed MAC address field to Docker templates for containers that need a stable network identity across restarts, including DHCP reservations, router or firewall rules, switch ACLs, and monitoring.
 - Improvement: Show Docker container MAC addresses in Advanced View alongside existing network and IP information.
 - Fix: Migrate legacy `--mac-address=` values from Extra Parameters into the new fixed MAC field where safe, while leaving templates unchanged when networking is still owned by Extra Parameters.
 - Fix: Prevent duplicate Docker user templates when container names and template filenames differ only by case on case-sensitive boot storage, such as ZFS internal boot.
-- Fix: Hide stale dead or uninspectable "phantom" containers that became newly visible after the Docker 27 to 29 upgrade path. This filters confusing leftovers out of the WebGUI without mutating Docker state. Background: [Docker 29 release notes](https://docs.docker.com/engine/release-notes/29/).
 - Fix: Add the missing support needed for Strix Point iGPU Docker workloads on affected systems. See the [user report](https://product.unraid.net/p/strix-point-igpu-support).
-- Fix: Prevent VMs created from user-defined templates from inheriting the source VM MAC address.
+- Fix: Keep the WebGUI responsive while adding Docker containers from the Add Container page.
 
 ### Storage
 
@@ -87,18 +130,21 @@ To proactively switch to TPM-based licensing, see [How can I move from flash-bas
 - Improvement: Improve visibility into pool and drive health information.
 - Improvement: Improve duplicate drive detection and related messaging.
 - Fix: Address sector-size compatibility regressions for 4Kn devices and some LSI HBA setups using 512e disks that affect XFS-formatted array disks.
+- Fix: Address an md/unraid driver crash that could make encrypted XFS array disks report a missing or wrong encryption key when affected systems used 4Kn parity.
 - Fix: 4Kn devices formatted XFS with 7.3.0-beta.1 or newer can now be moved out of the array and mounted normally in pools or other Linux systems. Older XFS filesystems that were formatted inside the array on 4Kn disks in previous Unraid releases still cannot be corrected without reformatting.
 - Fix: Prevent drives from spinning down during parity copy as part of parity swap.
-- Fix: Correct mover availability when emptying an array disk with no pool assigned.
 - Fix: Correct ZFS pools waking once every 24 hours in affected cases.
 - Fix: Correct pool-device detection for larger device names, including devices such as `sdp` and `sdap`, so affected pool disks no longer appear as `Unknown`.
+- Fix: Correct ZFS pool replacement handling when a dropped device is marked `REMOVED`, so replacement workflows no longer leave the pool degraded with a stale blue new-device state or repeated overwrite warning.
+- Fix: Allow adding a device to a formatted split boot pool when the data partition is formatted as ZFS or BTRFS.
+- Fix: Prevent creation of ZFS pools whose names use reserved ZFS name prefixes such as `mirror`, `raidz`, `raidz1`, `raidz2`, `raidz3`, or `spare`.
 
 ### WebGUI / System
 
 - Improvement: Refresh WebGUI and system-device workflows for the 7.3 internal-boot and hardware-support work.
 - Improvement: Add support for the Cooler Master Qube 500 case model.
+- New: Show chassis serial number in System Info when a valid chassis serial is available.
 - Fix: Handle CRLF line endings in Syslinux and GRUB configuration files so the Boot Parameters page can read settings edited from Windows.
-- Fix: Correct File Manager styling on the Main tab so it follows the selected theme.
 - Fix: Correct RAM display parsing after dmidecode unit label changes.
 - Fix: Correct time zone label and identifier issues in affected regions.
 - Fix: Restore the `Bind selected to vfio` action in System Devices on affected setups.
@@ -107,10 +153,8 @@ To proactively switch to TPM-based licensing, see [How can I move from flash-bas
 - Fix: Persist the built-in `rclone` configuration in a persistent location across reboot.
 - Fix: Correct strict proxy connectivity checks when using HTTP proxies that block CONNECT on port 80.
 - Fix: Correct rc.crond status typo.
-- Fix: Auto-restart SSH daemon after network recovery.
 - Fix: Correct Discord notification formatting issues.
-- Fix: Correct interface parsing when `ip addr` output includes peer information.
-- Fix: Correct custom image case model handling on the login page.
+- Fix: Correct stale status display after affected storage replacement workflows.
 - Fix: Remove outdated ReiserFS warnings and stale references.
 
 ### File Manager
@@ -118,6 +162,7 @@ To proactively switch to TPM-based licensing, see [How can I move from flash-bas
 - Improvement: Improve File Manager UI and overall performance.
 - Improvement: Improve same-filesystem move operations.
 - Improvement: Improve upload behavior.
+- Fix: Correct File Manager styling on the Main tab so it follows the selected theme.
 - Fix: Correct path handling issues involving `/sub/` in file paths.
 - Fix: Correct scrollbar interaction issues during copy or move operations.
 - Fix: Correct handling of double quotes in directory names.
@@ -138,158 +183,171 @@ To proactively switch to TPM-based licensing, see [How can I move from flash-bas
 - Fix: Address virtiofs hangs seen with affected Linux guests.
 - Fix: Correct VM snapshot commit cleanup not updating snapshot metadata correctly.
 - Fix: Correct libvirt startup issues encountered during testing.
-
-### Unraid API
-
-- `dynamix.unraid.net` 4.32.3 - [see changes](https://github.com/unraid/api/releases)
+- Fix: Prevent VMs created from user-defined templates from inheriting the source VM MAC address.
+- Fix: Update deprecated VM machine types during startup so older VMs do not fail with unsupported QEMU machine-type errors after upgrading.
+- Fix: Restore the Unraid UEFI logo for VMs.
+- Fix: Show the assigned `RenderGPU` for the first VM in the VM list when using Virtio 3D.
 
 ### Linux kernel
 
-- Linux kernel: version `6.18.23-Unraid`
+- Linux kernel: update from `6.12.85-Unraid` to `6.18.23-Unraid`.
 
 ### Base distro updates
 
-- aaa_libraries: version 15.1
-- at-spi2-core: version 2.58.3
-- bash: version 5.3.009
-- bash-completion: version 2.17.0
-- bind: version 9.20.20
-- brotli: version 1.2.0
-- btrfs-progs: version 6.19
-- ca-certificates: version 20260212
-- cifs-utils: version 7.5
-- coreutils: version 9.10
-- cryptsetup: version 2.8.4
-- curl: version 8.18.0
-- dmidecode: version 3.7
-- dnsmasq: version 2.92
-- docker: version 29.3.1
-- dynamix.unraid.net: version 4.32.3
+#### Removed packages
+
+- reiserfsprogs: version 3.6.27-5 removed
+
+#### Added packages
+
 - efibootmgr: version 18
 - efivar: version 20201015_cff88dd
-- elfutils: version 0.194
-- elogind: version 255.22
-- etc: version 15.1
-- ethtool: version 6.19
-- exfatprogs: version 1.3.1
-- file: version 5.47
-- freeglut: version 3.8.0
-- freetype: version 2.14.2
-- gawk: version 5.4.0
-- gdk-pixbuf2: version 2.44.5
 - gettext: version 1.0
 - gettext-tools: version 1.0
-- git: version 2.53.0
-- glew: version 2.3.1
-- glib2: version 2.86.4
-- glibc-zoneinfo: version 2026a
-- gnutls: version 3.8.12
-- grub: version 2.14
-- gtk+3: version 3.24.51
-- harfbuzz: version 13.0.0
-- icu4c: version 78.2
-- iotop-c: version 1.30
-- iperf3: version 3.20
-- iproute2: version 6.19.0
-- iptables: version 1.8.13
-- jansson: version 2.15.0
-- krb5: version 1.22.2
-- less: version 692
-- libarchive: version 3.8.5
-- libcap-ng: version 0.9.1
-- libdeflate: version 1.25
+- iotop-c: version 1.30-1_SBo
 - libdisplay-info: version 0.3.0
-- libdrm: version 2.4.131
-- libevdev: version 1.13.6
-- libfontenc: version 1.1.9
-- libgcrypt: version 1.12.1
-- libgpg-error: version 1.59
-- libjpeg-turbo: version 3.1.3
-- libnetfilter_conntrack: version 1.1.1
-- libnftnl: version 1.3.1
-- libnl3: version 3.12.0
-- libnvme: version 1.16.1
-- libpcap: version 1.10.6
-- libpng: version 1.6.55
-- libtasn1: version 4.21.0
-- libunistring: version 1.4.2
-- liburing: version 2.14
-- libvirt: version 12.2.0
-- libvirt-php: version 0.5.8_abf2ec0-x86_64-1_LT
-- libX11: version 1.8.13
-- libx86: version 1.1.1
-- libXcomposite: version 0.4.7
-- libXdamage: version 1.1.7
-- libXext: version 1.3.7
-- libXinerama: version 1.1.6
-- libxkbcommon: version 1.13.1
-- libxkbfile: version 1.2.0
-- libxml2: version 2.15.2
-- libXmu: version 1.3.1
-- libXpm: version 3.5.18
-- libXrandr: version 1.5.5
-- libxslt: version 1.1.45
-- libXxf86dga: version 1.1.7
-- libXxf86vm: version 1.1.7
-- lmdb: version 0.9.35
-- lsof: version 4.99.6
-- lvm2: version 2.03.38
-- mcelog: version 210
-- mesa: version 26.0.1
-- nano: version 8.7.1
-- ncurses: version 6.6
-- nfs-utils: version 2.8.5
-- nghttp2: version 1.68.0
-- nghttp3: version 1.15.0
-- noto-fonts-ttf: version 2026.03.01
-- ntp: version 4.2.8p18
-- nvme-cli: version 2.16
-- openssl: version 3.5.5
-- ovmf-stable: version 202508
-- p11-kit: version 0.26.2
-- pam: version 1.7.2
-- pango: version 1.57.0
-- pcre2: version 10.47
-- php: version 8.4.15-x86_64-1_LT
-- pkgtools: version 15.1
-- procps-ng: version 4.0.6
-- qemu: version 10.2.2
-- rclone: version 1.72.0-x86_64-1_SBo_LT
-- readline: version 8.3.003
-- shadow: version 4.19.4
-- spirv-llvm-translator: version 20260218_56778655
-- sqlite: version 3.51.2
-- sysstat: version 12.7.9
-- talloc: version 2.4.4
-- tdb: version 1.4.15
-- telnet: version 0.17
-- tpm2-tools: version 5.7
-- tpm2-tss: version 4.1.3
-- userspace-rcu: version 0.15.6
-- util-linux: version 2.41.3
-- virglrenderer: version 1.2.0
-- virtiofsd: version 1.13.2
-- wireguard-tools: version 1.0.20260223
-- wireless-regdb: version 2026.02.04
-- xauth: version 1.1.5
-- xfsprogs: version 6.18.0
-- xkbcomp: version 1.5.0
-- xkeyboard-config: version 2.47
-- xkill: version 1.0.7
-- xorg-server: version 21.1.21
-- xterm: version 407
-- xz: version 5.8.2
-- zfs: version 2.4.1
-- zlib: version 1.3.2
+- tpm2-tools: version 5.7-1_SBo
+- tpm2-tss: version 4.1.3-1_SBo
 
-## Pre-release tester notes
+#### Updated packages
 
-### CHANGES FROM BETA.2
-
-- Docker template MAC handling now has a dedicated fixed MAC field and shows live MAC addresses in Advanced View.
-- Docker template lookup now handles case-only filename differences on case-sensitive boot storage.
-- Boot pool and pool-device display fixes for missing, wrong, or larger device names.
-- CRLF handling for Syslinux and GRUB configuration files.
-- File Manager theme fix on the Main tab.
-- QEMU `10.2.2`, libvirt `12.2.0`, refreshed OVMF firmware, and a virtiofs hang fix.
-- `dynamix.unraid.net` `4.32.3`.
+- aaa_libraries: version 15.1-45 -> 15.1-50
+- adwaita-icon-theme: version 49.0 -> 50.0
+- at-spi2-core: version 2.58.1 -> 2.60.3
+- bash: version 5.3.003 -> 5.3.009
+- bash-completion: version 2.16.0 -> 2.17.0
+- brotli: version 1.1.0-3 -> 1.2.0
+- btrfs-progs: version 6.17 -> 6.19.1
+- ca-certificates: version 20251003 -> 20260413
+- cifs-utils: version 7.4 -> 7.5
+- coreutils: version 9.8-2 -> 9.11
+- cryptsetup: version 2.8.1 -> 2.8.6
+- curl: version 8.19.0 -> 8.20.0
+- dmidecode: version 3.6 -> 3.7
+- dnsmasq: version 2.91 -> 2.92
+- docker: version 29.3.1-1_LT -> 29.4.1-1_LT
+- dynamix.unraid.net: version 4.32.3-2 -> 4.33.0
+- e2fsprogs: version 1.47.3 -> 1.47.4
+- editres: version 1.0.9 -> 1.1.1
+- elfutils: version 0.193 -> 0.195
+- elogind: version 255.17 -> 255.23
+- etc: version 15.1-15 -> 15.1-16
+- ethtool: version 6.15 -> 7.0
+- eudev: version 3.2.14-2 -> 3.2.14-3
+- exfatprogs: version 1.3.0 -> 1.3.2
+- file: version 5.46-2 -> 5.47-2
+- freeglut: version 3.6.0 -> 3.8.0
+- freetype: version 2.14.1 -> 2.14.3
+- fuse3: version 3.16.2 -> 3.16.2-2
+- gawk: version 5.3.2 -> 5.4.0
+- gdk-pixbuf2: version 2.44.4-2 -> 2.44.6
+- git: version 2.51.1 -> 2.54.0
+- glew: version 2.2.0-3 -> 2.3.1
+- glib2: version 2.86.1 -> 2.88.1
+- glibc-zoneinfo: version 2025b -> 2026b
+- gnutls: version 3.8.12 -> 3.8.13 (CVE-2026-33846)
+- grub: version 2.12-18 -> 2.14-3
+- gtk+3: version 3.24.51 -> 3.24.52
+- harfbuzz: version 12.1.0 -> 14.2.0
+- htop: version 3.4.1 -> 3.5.1
+- icu4c: version 77.1 -> 78.3
+- infozip: version 6.0-7 -> 6.0-8 (CVE-2014-8139, CVE-2014-8140, CVE-2014-8141, CVE-2016-9844, CVE-2018-18384, CVE-2018-1000035, CVE-2021-4217, CVE-2022-0529, CVE-2022-0530)
+- iperf3: version 3.18-1cf -> 3.20-1cf
+- iproute2: version 6.17.0 -> 7.0.0
+- iptables: version 1.8.11 -> 1.8.13
+- jansson: version 2.14.1 -> 2.15.0
+- jemalloc: version 5.3.0-2 -> 5.3.1
+- krb5: version 1.22.1-2 -> 1.22.2-2
+- less: version 685 -> 692
+- libX11: version 1.8.12-2 -> 1.8.13
+- libXcomposite: version 0.4.6 -> 0.4.7
+- libXdamage: version 1.1.6 -> 1.1.7
+- libXext: version 1.3.6 -> 1.3.7
+- libXinerama: version 1.1.5 -> 1.1.6
+- libXmu: version 1.2.1 -> 1.3.1
+- libXrandr: version 1.5.4 -> 1.5.5
+- libXxf86dga: version 1.1.6 -> 1.1.7
+- libXxf86vm: version 1.1.6 -> 1.1.7
+- libcap-ng: version 0.8.5-2 -> 0.9.3
+- libdeflate: version 1.24 -> 1.25
+- libdrm: version 2.4.127 -> 2.4.133
+- libevdev: version 1.13.5 -> 1.13.6
+- libfontenc: version 1.1.8 -> 1.1.9
+- libgcrypt: version 1.11.2 -> 1.12.2
+- libgpg-error: version 1.56 -> 1.60
+- libjpeg-turbo: version 3.1.2 -> 3.1.4.1
+- libnetfilter_conntrack: version 1.1.0 -> 1.1.1
+- libnftnl: version 1.3.0 -> 1.3.1
+- libnl3: version 3.11.0 -> 3.12.0
+- libnvme: version 1.15 -> 1.16.1
+- libpciaccess: version 0.18.1 -> 0.19
+- libpng: version 1.6.57 -> 1.6.58
+- libunistring: version 1.4.1 -> 1.4.2
+- liburing: version 2.12 -> 2.14
+- libuv: version 1.51.0 -> 1.52.1
+- libvirt: version 11.7.0-1cf_LT -> 12.2.0-1cf_LT
+- libvirt-php: version 0.5.8-8.3.29_LT -> 0.5.8-8.4.15_LT
+- libx86: version 1.1-5 -> 1.1.1
+- libxkbcommon: version 1.11.0 -> 1.13.1
+- libxkbfile: version 1.1.3 -> 1.2.0
+- listres: version 1.0.6 -> 1.0.7
+- lmdb: version 0.9.33 -> 0.9.35
+- lsof: version 4.99.5 -> 4.99.6
+- lvm2: version 2.03.35 -> 2.03.40
+- lzip: version 1.25 -> 1.26
+- lzlib: version 1.15 -> 1.16
+- mcelog: version 207 -> 210
+- mesa: version 25.2.5 -> 26.0.6
+- mkfontscale: version 1.2.3 -> 1.2.4
+- nano: version 8.6 -> 9.0
+- ncurses: version 6.5_20250816 -> 6.6
+- nfs-utils: version 2.8.4 -> 2.9.1
+- nghttp2: version 1.67.1 -> 1.69.0
+- nghttp3: version 1.12.0 -> 1.15.0
+- noto-fonts-ttf: version 2025.10.01 -> 2026.05.01
+- ntfs-3g: version 2022.10.3 -> 2026.2.25
+- ntp: version 4.2.8p18-7 -> 4.2.8p18-8
+- nvme-cli: version 2.15 -> 2.16
+- openssh: version 10.2p1 -> 10.3p1
+- ovmf: version unraid202502 -> stable202602-2
+- pam: version 1.7.1 -> 1.7.2
+- pango: version 1.56.4 -> 1.57.1
+- parted: version 3.6 -> 3.7
+- pciutils: version 3.14.0 -> 3.15.0
+- pcre2: version 10.46 -> 10.47
+- perl: version 5.42.0 -> 5.42.2-2
+- php: version 8.3.29-1_LT -> 8.4.18-1_LT
+- pkgtools: version 15.1-30 -> 15.1-31
+- procps-ng: version 4.0.5 -> 4.0.6
+- qemu: version 9.2.3-1cf_LT -> 10.2.2-1_SBo_LT
+- rclone: version 1.70.1-1_SBo_LT -> 1.72.0-1_SBo_LT
+- readline: version 8.3.001-2 -> 8.3.003
+- rsync: version 3.4.1 -> 3.4.2
+- sed: version 4.9 -> 4.10
+- setxkbmap: version 1.3.4 -> 1.3.5
+- shadow: version 4.18.0 -> 4.19.4-2
+- spirv-llvm-translator: version 21.1.1 -> 22.1.2
+- sqlite: version 3.50.4 -> 3.53.0
+- sysstat: version 12.7.8 -> 12.7.9
+- sysvinit: version 3.15 -> 3.18
+- sysvinit-scripts: version 15.1-35 -> 15.1-36
+- talloc: version 2.4.3 -> 2.4.4
+- tdb: version 1.4.14 -> 1.4.15
+- telnet: version 0.17-7 -> 0.17-8 (CVE-2020-10188)
+- tree: version 2.2.1 -> 2.3.1
+- userspace-rcu: version 0.15.3 -> 0.15.6
+- util-linux: version 2.41.2 -> 2.42-2
+- virglrenderer: version 1.1.1-1cf -> 1.2.0-1cf
+- virtiofsd: version 1.13.1-1cf -> 1.13.2-1cf
+- wayland: version 1.24.0 -> 1.25.0
+- wireguard-tools: version 1.0.20250521 -> 1.0.20260223
+- wireless-regdb: version 2025.10.07 -> 2026.03.18
+- xauth: version 1.1.4 -> 1.1.5
+- xfsprogs: version 6.17.0 -> 6.19.0
+- xkbcomp: version 1.4.7 -> 1.5.0
+- xkeyboard-config: version 2.46 -> 2.47
+- xkill: version 1.0.6 -> 1.0.7
+- xorg-server: version 21.1.22-2 -> 21.1.22-3 (CVE-2026-33999, CVE-2026-34000, CVE-2026-34001, CVE-2026-34002, CVE-2026-34003)
+- xrandr: version 1.5.3 -> 1.5.4
+- xterm: version 403 -> 410
+- zfs: version 2.3.4_6.12.82_Unraid-2_LT -> 2.4.1_6.18.26_Unraid-1_LT


### PR DESCRIPTION
## Summary

- Update the 7.3.0 release notes from rc.1 to rc.2.
- Add the rc.2-only change summary for security, licensing, Docker, storage, WebGUI/system, and virtualization.
- Keep the previously included rc.1 changelog relative to 7.2.5 in the same page.

## Validation

- `pnpm exec remark docs/unraid-os/release-notes/7.3.0.md --quiet --frail`
- `pnpm exec prettier --check docs/unraid-os/release-notes/7.3.0.md`
- `git diff --check -- docs/unraid-os/release-notes/7.3.0.md`

Full build not run per repo instructions for routine docs validation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Updated release notes for version 7.3.0-rc.2 with clarifications on system requirements and important rollback warnings
* Added guidance on ZFS pool naming, storage device configurations, and upgrade constraints  
* Documented updates across security, licensing, storage, virtualization, and system components with version information

<!-- end of auto-generated comment: release notes by coderabbit.ai -->