### PR TITLE
feat: 7.3.0 stable changelog

### DIFF
--- a/docs/unraid-os/release-notes/7.3.0.md
+++ b/docs/unraid-os/release-notes/7.3.0.md
@@ -20,7 +20,7 @@ For step-by-step instructions, see [Updating Unraid](/unraid-os/updating-unraid/
 - If a dual-device boot pool contains a device with an unformatted data partition, removing one boot-pool device may not complete correctly.
 - If a split boot-pool device is removed and another device is added immediately afterward, the slot count may not always update until the server is rebooted.
 - Some UPS devices may report **Online No battery detected** and log repeated `Event data for report 22 was too short` messages. If affected, the NUT plugin may provide a working UPS monitoring path.
-- Some Docker containers on VLAN networks may fail to receive DHCP or use the expected static network configuration after upgrading from 7.2.4 or 7.2.5. This is still under investigation.
+- Some Docker containers on VLAN networks may fail to receive DHCP or use the expected static network configuration after upgrading from 7.2.4 or 7.2.5. This release has a possible mitigation for this issue.
 
 ### Notes
 

--- a/docs/unraid-os/release-notes/7.3.0.md
+++ b/docs/unraid-os/release-notes/7.3.0.md
@@ -1,8 +1,6 @@
-# Version 7.3.0-rc.2 2026-05-06
+# Version 7.3.0 2026-05-12
 
-This release candidate builds on 7.3.0-rc.1 with targeted fixes for internal boot, ZFS pool replacement workflows, virtualization, Docker, TPM-based licensing, WebGUI security hardening, and other miscellaneous bug fixes.
-
-This is RELEASE CANDIDATE software. Please use on test servers only.
+This stable release adds internal boot support, an onboarding wizard, TPM-based licensing, Docker networking improvements, expanded hardware support, ZFS and storage fixes, virtualization updates, WebGUI security hardening, and package updates.
 
 ## Upgrading
 
@@ -10,19 +8,19 @@ For step-by-step instructions, see [Updating Unraid](/unraid-os/updating-unraid/
 
 ### Known issues
 
-See [Unraid OS Pre-release (Bugs & Feedback)](https://product.unraid.net/b/unraid-os-prerelease-bugs-feedback) for issues reported by other testers.
-
 - During internal boot setup, the WebGUI may show **Array Offline** while internal boot configures. **DO NOT** manually restart or remove your flash drive during this process.
 - Internal boot requires boot storage that can be accessed by built-in Linux drivers during startup. Devices that require third-party drivers or post-boot configuration cannot be used for internal boot. Unraid supports the following drivers for internal boot:
-  - mvsas (rc.2)
-  - mpt3sas
-  - smartpqi (rc.2)
-  - nvme
   - ahci
   - mmc
+  - mpt3sas
+  - mvsas
+  - nvme
+  - smartpqi
   - USB (`usb-storage` and `uas`, also known as UASP)
-- Some invalid ZFS pool names that begin with reserved ZFS prefixes may fail without a clear WebGUI error. Choose a different pool name if creation does not complete.
+- If a dual-device boot pool contains a device with an unformatted data partition, removing one boot-pool device may not complete correctly.
 - If a split boot-pool device is removed and another device is added immediately afterward, the slot count may not always update until the server is rebooted.
+- Some UPS devices may report **Online No battery detected** and log repeated `Event data for report 22 was too short` messages. If affected, the NUT plugin may provide a working UPS monitoring path.
+- Some Docker containers on VLAN networks may fail to receive DHCP or use the expected static network configuration after upgrading from 7.2.4 or 7.2.5. This is still under investigation.
 
 ### Notes
 
@@ -31,79 +29,27 @@ See [Unraid OS Pre-release (Bugs & Feedback)](https://product.unraid.net/b/unrai
 
 ### Rolling back
 
-- If you already enabled internal boot or switched to TPM-based licensing while testing the 7.3 pre-release, you can roll back to `7.3.0-rc.1` without issue.
-- Do not roll back to `7.2.5` or earlier after enabling internal boot or TPM-based licensing.
+- Do not roll back to `7.2.6` or earlier after enabling internal boot or TPM-based licensing.
 - If you upgrade ZFS pool features, earlier Unraid releases may not be able to import those pools.
-- If you need to roll back, follow the normal pre-release rollback process before moving between builds.
+- If you need to roll back, follow the normal rollback process before moving between builds.
 
-If you are considering any rollback path below `7.3.0-rc.1`, also see the [7.2.4 release notes](/unraid-os/release-notes/7.2.4/).
+If you are considering any rollback path below `7.3.0`, also see the [7.2.6 release notes](/unraid-os/release-notes/7.2.6/).
 
-## Changes from 7.3.0-rc.1
-
-Only the items in this section are new or materially updated in rc.2. Broader changes from 7.2.5 are included below.
+## Changes vs. [7.2.6](/unraid-os/release-notes/7.2.6/)
 
 ### Security
 
-- Security: Add WebGUI security hardening for authenticated-session request handling. Upgrade recommended. This security fix is also present in 7.2.5.
-- Security note: The included 7.3 kernel already contains the fix for CVE-2026-31431, the Copy Fail local privilege escalation vulnerability. This security fix is also present in 7.2.5.
-
-### Licensing
-
-- Fix: Improve TPM-based license replacement blacklist handling so a transferred TPM-based key is blocked without permanently blocking the underlying motherboard GUID from future valid activation.
-
-### Containers / Docker
-
-- Improvement: Update Docker to version `29.4.1`.
-
-### Storage
-
-- New: Add mvsas and smartpqi as built-in storage drivers so they can be used for internal boot.
-- Fix: Address an md/unraid driver crash.
-- Fix: Correct ZFS pool replacement handling when a dropped device is marked `REMOVED`, so replacement workflows no longer leave the pool degraded with a stale blue new-device state or repeated overwrite warning.
-- Fix: Improve dedicated and split boot-pool detection after boot-pool devices are replaced with larger devices.
-- Fix: Allow adding a device to a formatted split boot pool when the data partition is formatted as ZFS or BTRFS.
-- Fix: Prevent creation of ZFS pools whose names start with reserved ZFS name prefixes: `mirror`, `raidz`, `draid`, and `spare`.
-
-### WebGUI / System
-
-- New: Show chassis serial number in System Info when a valid chassis serial is available.
-- Fix: Keep the WebGUI responsive while adding Docker containers from the Add Container page.
-- Fix: Correct stale status display after affected storage replacement workflows.
-- Fix: Use online / offline instead of on-line / off-line in various text.
-
-### Virtualization
-
-- Fix: Update deprecated VM machine types during startup so older VMs do not fail with unsupported QEMU machine-type errors after upgrading.
-- Fix: Show the assigned `RenderGPU` for the first VM in the VM list when using Virtio 3D.
-
-## Changes vs. [7.2.5](/unraid-os/release-notes/7.2.5/)
-
-### Security
-
-- Security: Add WebGUI security hardening for authenticated-session request handling. Upgrade recommended.
-- Security: Update `bind` from `9.20.13` to `9.20.20`.
-- Security note: The included 7.3 kernel contains the fix for CVE-2026-31431, the Copy Fail local privilege escalation vulnerability.
+- Security: Add WebGUI security hardening for authenticated-session request handling. This fix is already included in 7.2.5.
+- Security: Update packages
+- Security note: The included 7.3 kernel contains the fix for CVE-2026-31431, the Copy Fail local privilege escalation vulnerability as well as CVE-2025-43284 Dirty Frag local privilege escalation vulnerability.
 
 ### Onboarding and internal boot
 
 New users automatically start in the onboarding wizard, where they choose language, time zone, theme, activation code settings, and boot option, including internal boot.
 
-Existing users can go to **_Settings → Onboarding Wizard_** to review settings and migrate to internal boot.
+Existing users can go to **_Tools → Onboarding Wizard_** to review settings and migrate to internal boot.
 
 For details, see [Onboarding](/unraid-os/getting-started/set-up-unraid/deploy-and-configure-unraid-os/).
-
-- New: Add dedicated boot pool support as a distinct option from split boot pools.
-- Improvement: Move the Onboarding Wizard under Tools and add a direct internal-boot device link when setup still needs attention.
-- Improvement: Update many user-facing strings from "Flash" to "Boot".
-- Improvement: Improve organization of boot-related settings.
-- Fix: Force the expected reboot or shutdown flow after internal boot setup.
-- Fix: Restore the Boot page browse icon on affected systems.
-- Fix: Correct black-theme dropdown visibility in the Onboarding Wizard.
-- Fix: Correct the GMT time zone selection state in the Onboarding Wizard.
-- Fix: Correct the New Config tool so it handles boot pools properly.
-- Fix: Allow pools that were previously configured as boot pools to be removed correctly.
-- Fix: Keep the boot pool visible when an expected boot-pool disk is missing or a wrong disk is selected.
-- Fix: Improve dedicated and split boot-pool detection after boot-pool devices are replaced with larger devices.
 
 ### Licensing
 
@@ -111,16 +57,12 @@ All new and replacement keys use TPM-based licensing when possible because it is
 
 To proactively switch to TPM-based licensing, see [How can I move from flash-based licensing to TPM-based licensing](/unraid-os/troubleshooting/tpm-licensing-faq/#tpm).
 
-- Improvement: Improve handling of missing key file states.
-- Fix: Improve TPM-based license replacement blacklist handling so a transferred TPM-based key is blocked without permanently blocking the underlying motherboard GUID from future valid activation.
-
 ### Containers / Docker
 
-- Improvement: Update Docker from `29.3.1` to `29.4.1`.
+- Improvement: Update Docker from `29.3.1` to `29.4.3`.
 - New: Add an optional fixed MAC address field to Docker templates for containers that need a stable network identity across restarts, including DHCP reservations, router or firewall rules, switch ACLs, and monitoring.
 - Improvement: Show Docker container MAC addresses in Advanced View alongside existing network and IP information.
 - Fix: Migrate legacy `--mac-address=` values from Extra Parameters into the new fixed MAC field where safe, while leaving templates unchanged when networking is still owned by Extra Parameters.
-- Fix: Prevent duplicate Docker user templates when container names and template filenames differ only by case on case-sensitive boot storage, such as ZFS internal boot.
 - Fix: Add the missing support needed for Strix Point iGPU Docker workloads on affected systems. See the [user report](https://product.unraid.net/p/strix-point-igpu-support).
 - Fix: Keep the WebGUI responsive while adding Docker containers from the Add Container page.
 
@@ -130,32 +72,26 @@ To proactively switch to TPM-based licensing, see [How can I move from flash-bas
 - New: Add user-facing control for ZFS ARC max size on **_Settings → Disk Settings → Tunable (zfs_arc_max)_**. This used to be controlled through a custom ZFS driver parameter. You may need to migrate your setting to the new location.
 - Improvement: Improve visibility into pool and drive health information.
 - Improvement: Improve duplicate drive detection and related messaging.
-- Fix: Address sector-size compatibility regressions for 4Kn devices and some LSI HBA setups using 512e disks that affect XFS-formatted array disks.
-- Fix: Address an md/unraid driver crash that could make encrypted XFS array disks report a missing or wrong encryption key when affected systems used 4Kn parity.
-- Fix: 4Kn devices formatted XFS with 7.3.0-beta.1 or newer can now be moved out of the array and mounted normally in pools or other Linux systems. Older XFS filesystems that were formatted inside the array on 4Kn disks in previous Unraid releases still cannot be corrected without reformatting.
 - Fix: Prevent drives from spinning down during parity copy as part of parity swap.
 - Fix: Correct ZFS pools waking once every 24 hours in affected cases.
-- Fix: Correct pool-device detection for larger device names, including devices such as `sdp` and `sdap`, so affected pool disks no longer appear as `Unknown`.
 - Fix: Correct ZFS pool replacement handling when a dropped device is marked `REMOVED`, so replacement workflows no longer leave the pool degraded with a stale blue new-device state or repeated overwrite warning.
-- Fix: Allow adding a device to a formatted split boot pool when the data partition is formatted as ZFS or BTRFS.
-- Fix: Prevent creation of ZFS pools whose names use reserved ZFS name prefixes such as `mirror`, `raidz`, `raidz1`, `raidz2`, `raidz3`, or `spare`.
+- Fix: Prevent creation of ZFS pools whose names use reserved ZFS name prefixes such as `mirror`, `raidz`, `draid`, or `spare`.
 
 ### WebGUI / System
 
 - Improvement: Refresh WebGUI and system-device workflows for the 7.3 internal-boot and hardware-support work.
 - Improvement: Add support for the Cooler Master Qube 500 case model.
 - New: Show chassis serial number in System Info when a valid chassis serial is available.
-- Fix: Handle CRLF line endings in Syslinux and GRUB configuration files so the Boot Parameters page can read settings edited from Windows.
+- Improvement: Show a clearer licensing status message when no valid TPM or flash licensing device is detected.
 - Fix: Correct RAM display parsing after dmidecode unit label changes.
 - Fix: Correct time zone label and identifier issues in affected regions.
-- Fix: Restore the `Bind selected to vfio` action in System Devices on affected setups.
 - Fix: Stop WebGUI and API requests from spinning up the full HDD array on affected systems.
-- Fix: Restore CPU isolation saving so selected cores apply correctly again.
 - Fix: Persist the built-in `rclone` configuration in a persistent location across reboot.
 - Fix: Correct strict proxy connectivity checks when using HTTP proxies that block CONNECT on port 80.
 - Fix: Correct rc.crond status typo.
 - Fix: Correct Discord notification formatting issues.
-- Fix: Correct stale status display after affected storage replacement workflows.
+- Fix: Correct FTP help text so it states that FTP is disabled by default.
+- Fix: Use online / offline instead of on-line / off-line in various text.
 - Fix: Remove outdated ReiserFS warnings and stale references.
 
 ### File Manager
@@ -181,25 +117,26 @@ To proactively switch to TPM-based licensing, see [How can I move from flash-bas
 - Improvement: Improve System Devices visibility and VM template workflows.
 - Improvement: Improve custom VNC port validation and defaults.
 - Improvement: Update QEMU to `10.2.2`, libvirt to `12.2.0`, and refresh the OVMF firmware package.
-- Fix: Address virtiofs hangs seen with affected Linux guests.
 - Fix: Correct VM snapshot commit cleanup not updating snapshot metadata correctly.
-- Fix: Correct libvirt startup issues encountered during testing.
 - Fix: Prevent VMs created from user-defined templates from inheriting the source VM MAC address.
 - Fix: Update deprecated VM machine types during startup so older VMs do not fail with unsupported QEMU machine-type errors after upgrading.
-- Fix: Restore the Unraid UEFI logo for VMs.
 - Fix: Show the assigned `RenderGPU` for the first VM in the VM list when using Virtio 3D.
 
 ### Linux kernel
 
-- Linux kernel: update from `6.12.85-Unraid` to `6.18.26-Unraid`.
+- Linux kernel: update to `6.18.28-Unraid`.
 
 ### Base distro updates
 
-#### Removed packages
+#### Removed packages (1)
 
 - reiserfsprogs: version 3.6.27-5 removed
 
-#### Added packages
+#### Downgraded packages (0)
+
+- None
+
+#### Added packages (8)
 
 - efibootmgr: version 18
 - efivar: version 20201015_cff88dd
@@ -210,7 +147,7 @@ To proactively switch to TPM-based licensing, see [How can I move from flash-bas
 - tpm2-tools: version 5.7-1_SBo
 - tpm2-tss: version 4.1.3-1_SBo
 
-#### Updated packages
+#### Updated packages (140)
 
 - aaa_libraries: version 15.1-45 -> 15.1-50
 - adwaita-icon-theme: version 49.0 -> 50.0
@@ -226,8 +163,8 @@ To proactively switch to TPM-based licensing, see [How can I move from flash-bas
 - curl: version 8.19.0 -> 8.20.0
 - dmidecode: version 3.6 -> 3.7
 - dnsmasq: version 2.91 -> 2.92
-- docker: version 29.3.1-1_LT -> 29.4.1-1_LT
-- dynamix.unraid.net: version 4.32.3-2 -> 4.33.0
+- docker: version 29.3.1-1_LT -> 29.4.3-1_LT
+- dynamix.unraid.net: version 4.32.3-2 -> 4.34.0
 - e2fsprogs: version 1.47.3 -> 1.47.4
 - editres: version 1.0.9 -> 1.1.1
 - elfutils: version 0.193 -> 0.195
@@ -351,4 +288,4 @@ To proactively switch to TPM-based licensing, see [How can I move from flash-bas
 - xorg-server: version 21.1.22-2 -> 21.1.22-3 (CVE-2026-33999, CVE-2026-34000, CVE-2026-34001, CVE-2026-34002, CVE-2026-34003)
 - xrandr: version 1.5.3 -> 1.5.4
 - xterm: version 403 -> 410
-- zfs: version 2.3.4_6.12.82_Unraid-2_LT -> 2.4.1_6.18.26_Unraid-1_LT
+- zfs: version 2.3.4_6.12.82_Unraid-2_LT -> 2.4.1_6.18.28_Unraid-1_LT


### PR DESCRIPTION
## Summary

- Updates the Unraid OS 7.3.0 release notes from rc.2 to the stable May 12 release.
- Replaces pre-release guidance with stable known issues, rollback notes, sectioned changes, and package updates from the Linear release note.
- Normalizes links and Markdown formatting for Docusaurus.
- Clarifies the Docker VLAN known issue to mention the possible mitigation included in this release.

## Validation

- `pnpm exec remark docs/unraid-os/release-notes/7.3.0.md --quiet --frail`
- `git diff --check -- docs/unraid-os/release-notes/7.3.0.md`

Full build intentionally not run per repo guidance for routine docs validation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added internal boot support with TPM-based licensing option
  * Enhanced security and licensing improvements

* **Improvements**
  * Updated Linux kernel and Docker versions
  * Refined storage and ZFS workflows with device replacement improvements
  * Enhanced WebGUI system functionality and user experience
  * Improved virtualization features and performance

* **Bug Fixes**
  * Resolved container networking and connectivity issues
  * Fixed spinning behavior and chassis serial display

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unraid/docs/pull/475)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->