### PR TITLE
docs: refresh release archive guidance

### DIFF
--- a/docs/unraid-os/download_list.mdx
+++ b/docs/unraid-os/download_list.mdx
@@ -3,12 +3,14 @@ sidebar_position: 9
 title: Version Archive
 ---
 
-import {VersionsTable} from '@site/src/components/VersionsTable';
+import { VersionsTable } from "@site/src/components/VersionsTable";
 
 # Version Archive
 
 Use this archive to find release notes and download links for Unraid OS versions. To update an existing server, use the built-in updater; see the [standard update process](./updating-unraid/index.mdx#standard-update-process) for steps. To create a new boot device, use the [Unraid USB Creator](https://unraid.net/download).
 
-If you are deciding which release to install, start with [Unraid OS release types](./updating-unraid/release-types.mdx).
+The archive groups releases by support status. Only the latest patch or pre-release build in a supported minor series receives updates as appropriate; older builds in the same series are superseded. Releases marked **EOL** are not supported and no longer include updates.
+
+If you are deciding which release to install, start with [Unraid OS release types](./updating-unraid/release-types.mdx). For license eligibility details, see the [Licensing FAQ](./troubleshooting/licensing-faq.mdx#no-extension).
 
 <VersionsTable />

--- a/docs/unraid-os/release-notes/7.2.7.md
+++ b/docs/unraid-os/release-notes/7.2.7.md
@@ -1,6 +1,6 @@
 # Release notes · Unraid OS 7.2.7
 
-# Version 7.2.7 2026-05-21
+## Version 7.2.7 2026-05-21
 
 This release focuses on security updates, Docker updates, and WebGUI fixes, along with package refreshes for core system components.
 
@@ -14,22 +14,22 @@ For step-by-step instructions, see [Updating Unraid](/unraid-os/updating-unraid/
 
 ### Security
 
-* Security updates for docker, nginx, glibc, jq, avahi, and glibc support libraries.
+- Security updates for docker, nginx, glibc, jq, avahi, and glibc support libraries.
 
 ### Containers / Docker
 
-* Docker 29.5.1
-* Docker VLAN containers keep their configured gateway after updates.
-* Docker container menus stay reachable on pages with many containers.
+- Docker 29.5.1
+- Docker VLAN containers keep their configured gateway after updates.
+- Docker container menus stay reachable on pages with many containers.
 
 ### WebGUI / System
 
-* Connect version checks restored in the server plugin.
+- Connect version checks restored in the server plugin.
 
 ### Linux kernel
 
-* kernel upgrade: 6.12.90-Unraid (CVE-2026-43490, CVE-2026-46333)
-* Performance regression affecting Docker-enabled systems and some USB 3.1 devices.
+- kernel upgrade: 6.12.90-Unraid (CVE-2026-43490, CVE-2026-46333)
+- Performance regression affecting Docker-enabled systems and some USB 3.1 devices.
 
 #### **Updated Packages (11)**
 

--- a/docs/unraid-os/troubleshooting/licensing-faq.mdx
+++ b/docs/unraid-os/troubleshooting/licensing-faq.mdx
@@ -47,7 +47,7 @@ For bulk OEM/reseller pricing (10 licenses or more), [contact Unraid](https://un
 
 ### How do I upgrade my Unraid license? {/* #upgrade-license */}
 
-You can upgrade your license at any time from within the %%WebGUI|web-gui%% (***Tools → Registration***) or [via the account portal](https://account.unraid.net/keys) (by clicking **••• More** and selecting **Upgrade Key**).
+You can upgrade your license at any time from within the %%WebGUI|web-gui%% (**_Tools → Registration_**) or [via the account portal](https://account.unraid.net/keys) (by clicking **••• More** and selecting **Upgrade Key**).
 
 <div style={{ display: "flex", justifyContent: "center", margin: "20px 0" }}>
 
@@ -66,15 +66,18 @@ You can upgrade your license at any time from within the %%WebGUI|web-gui%% (***
 
 **Annual extension fee** (Starter & Unleashed only): $36 USD
 
-<sup>1</sup> Attached storage devices include all devices present before array start, except one eMMC device and one USB device.\
-<sup>2</sup> "Unlimited" means you are not limited by the license, but by hardware and OS constraints. Additional storage devices can be used for %%VMs|vm%%, unassigned devices, or other Unraid features.\*
+<sup>1</sup> Attached storage devices include all devices present before array
+start, except one eMMC device and one USB device.\
+<sup>2</sup> "Unlimited" means you are not limited by the license, but by
+hardware and OS constraints. Additional storage devices can be used for
+%%VMs|vm%%, unassigned devices, or other Unraid features.\*
 
 ### How do I manually install my license keyfile to my boot device? {/* #manual-keyfile-install */}
 
 #### Install via WebGUI download
 
 1. Navigate to [account.unraid.net/keys](https://account.unraid.net/keys), select **View options** next to your key, then click **Copy Key URL**.
-2. Navigate to your server's ***Tools → Registration***.
+2. Navigate to your server's **_Tools → Registration_**.
 3. Scroll to the bottom of the Registration page, to the **Install Key** section.
 4. Paste the URL into the **Key file URL** field, and click **Install**.
 
@@ -88,16 +91,16 @@ You can upgrade your license at any time from within the %%WebGUI|web-gui%% (***
 
 This does not apply if you have configured internal boot.
 
-1. Ensure you have a recent backup of your USB drive. Use [Unraid Connect](../../unraid-connect/overview-and-setup.mdx) (recommended) or the local backup option at ***Main → Boot Device → Boot Device Backup*** (on releases before 7.3.0, use ***Main → Flash device → FLASH BACKUP***).
+1. Ensure you have a recent backup of your USB drive. Use [Unraid Connect](../../unraid-connect/overview-and-setup.mdx) (recommended) or the local backup option at **_Main → Boot Device → Boot Device Backup_** (on releases before 7.3.0, use **_Main → Flash device → FLASH BACKUP_**).
 2. Shut down your Unraid server and remove the USB boot device.
 3. Insert the USB drive into another computer.
 4. Open the USB drive and copy your `.key` file into the `/config` folder.
-   *Make sure this is the only `.key` file present - delete any others.*
+   _Make sure this is the only `.key` file present - delete any others._
 5. Safely eject the USB drive, reinstall it in your server, and reboot.
 
 ### How can I determine my registration type? {/* #registration-type */}
 
-Navigate to ***Tools → Registration*** in the %%WebGUI|web-gui%%. Here, you can find your current license type and registration details.
+Navigate to **_Tools → Registration_** in the %%WebGUI|web-gui%%. Here, you can find your current license type and registration details.
 
 For internal boot questions, see the [Internal Boot FAQ (7.3+)](../getting-started/set-up-unraid/internal-boot-faq.mdx).
 For TPM-based licensing questions, see the [TPM Licensing FAQ (7.3+)](tpm-licensing-faq.mdx).
@@ -120,16 +123,18 @@ You continue to own your license even if you stop paying for updates.
 
 - You keep your license and can use your current version of Unraid OS indefinitely.
 - You won't receive new feature updates or major version upgrades.
-- You remain eligible for patch releases and security updates within the same minor version (e.g., 7.1.x if your license lapsed at 7.1.0).
-- Once a new minor version is released (e.g., 7.2.0), only security patches are provided for the previous minor version.
-- When a version reaches end-of-life (EOL), no further updates are provided.
-- You can pay the extension fee at any time to regain access to the latest updates.
+- You remain eligible for updates to the latest patch release within your minor version (e.g., if your license lapsed at 7.1.0, you can install any 7.1.x release while 7.1 is a supported minor version).
+- Lime Technology supports the two most recent publicly released minor versions at any given time. A "public" release includes Stable, Release Candidate (RC), and Beta builds.
+- When a newer minor or major version becomes public — including a public Beta or RC — the oldest currently supported minor version reaches end-of-life (EOL) and no further updates are issued for it.
+- Once your minor version is EOL, you can continue running it indefinitely, but you will no longer receive security patches or bug fixes. To receive updates again, extend your license at [unraid.net/pricing](https://unraid.net/pricing) and update to a supported version.
+- You can see the current support status of each release in the [Version Archive](https://docs.unraid.net/unraid-os/download_list/).
 
 ### What happens with pre-releases (Beta/RC versions)? {/* #pre-release-policy */}
 
 - Pre-release (Beta and Release Candidate) versions are for testing and may contain bugs.
 - Only install pre-releases on non-production systems.
-- Support for pre-releases ends when the stable version is released.
+- A public pre-release counts as the current public minor series when determining which minor series are supported.
+- Support for a specific pre-release build ends when it is superseded by a newer pre-release or the corresponding stable release.
 - Your license must be eligible for OS updates on the stable release date to receive the stable version.
 - If your license expires before the stable release, you must extend your license to upgrade or roll back to a supported stable version.
 - Your license remains valid after expiration; you only need an active license for new updates.
@@ -150,8 +155,11 @@ Here are the current limits:
 
 </div>
 
-<sup>1</sup> Attached storage devices include all devices present before %%array|array%% start, except one eMMC device and one USB device.\
-<sup>2</sup> "Unlimited" means you are not limited by the license, but by hardware and OS constraints. Additional storage devices can be used for %%VMs|vm%%, unassigned devices, or other Unraid features.\*
+<sup>1</sup> Attached storage devices include all devices present before
+%%array|array%% start, except one eMMC device and one USB device.\
+<sup>2</sup> "Unlimited" means you are not limited by the license, but by
+hardware and OS constraints. Additional storage devices can be used for
+%%VMs|vm%%, unassigned devices, or other Unraid features.\*
 
 ---
 
@@ -166,7 +174,7 @@ To transfer your license:
 1. Prepare new, high-quality [boot media](../getting-started/set-up-unraid/create-your-bootable-media.mdx) (for example a USB flash drive).
 2. Install Unraid OS on the new device using the USB Flash Creator or a manual method.
 3. Boot your server with the new boot device.
-4. Go to ***Tools → Registration*** in the %%WebGUI|web-gui%%.
+4. Go to **_Tools → Registration_** in the %%WebGUI|web-gui%%.
 5. Click **Replace Key** and follow the prompts to transfer your license to the new device.
 
 The first transfer can be done at any time, while subsequent transfers are allowed once every 12 months using the automated system. If you need to transfer your license again before the 12-month period, contact Unraid support with your old and new USB %%GUID|guid%%s for manual assistance.

--- a/docs/unraid-os/updating-unraid/release-types.mdx
+++ b/docs/unraid-os/updating-unraid/release-types.mdx
@@ -11,12 +11,27 @@ For most servers, use the latest **Stable** release. Use **Beta** or **Release C
 
 ## Release types at a glance
 
-| Release type | Example version | Best for | What to expect |
-| --- | --- | --- | --- |
-| **Stable** | `7.2.0`, then `7.2.1`, `7.2.2`, and later patches | Production servers | General availability release recommended for normal use. A stable series often begins with a `.0` minor release, then receives patch releases with fixes and compatibility updates. |
-| **Release Candidate (RC)** | `7.3.0-rc.1` | Final validation on test systems | A pre-release that is expected to be close to stable, but may still include unresolved issues or last-minute changes. |
-| **Beta** | `7.3.0-beta.2` | Early testing and feedback | A pre-release used to test new features, platform changes, fixes, and upgrade paths before the release is ready for stable use. |
-| **Withdrawn pre-release** | Varies | Moving off an unavailable test build | A beta or RC that is no longer enabled for regular use. Update to the latest stable release unless the release notes say otherwise. |
+| Release type               | Example version                                   | Best for                             | What to expect                                                                                                                                                                      |
+| -------------------------- | ------------------------------------------------- | ------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Stable**                 | `7.2.0`, then `7.2.1`, `7.2.2`, and later patches | Production servers                   | General availability release recommended for normal use. A stable series often begins with a `.0` minor release, then receives patch releases with fixes and compatibility updates. |
+| **Release Candidate (RC)** | `7.3.0-rc.1`                                      | Final validation on test systems     | A pre-release that is expected to be close to stable, but may still include unresolved issues or last-minute changes.                                                               |
+| **Beta**                   | `7.3.0-beta.2`                                    | Early testing and feedback           | A pre-release used to test new features, platform changes, fixes, and upgrade paths before the release is ready for stable use.                                                     |
+| **Withdrawn pre-release**  | Varies                                            | Moving off an unavailable test build | A beta or RC that is no longer enabled for regular use. Update to the latest stable release unless the release notes say otherwise.                                                 |
+
+## Supported minor series and EOL
+
+Unraid supports two public minor series at a time:
+
+- The **current public minor series**, such as `7.3.x` once any `7.3` beta, RC, or stable release is public.
+- The **previous public minor series**, such as `7.2.x` while `7.3.x` is the current public series.
+
+A public beta or RC counts as a public minor series for support-policy purposes. This does not mean beta or RC releases are recommended for production use; it only means the support window moves forward when the next minor series becomes public.
+
+Within a supported minor series, use the latest available patch or pre-release build for that series. Older patch builds in the same series are superseded and remain available only for archive, rollback, and release-note reference.
+
+Older minor series are **End of Life (EOL)**. EOL releases are not supported and no longer include bug fixes or security updates.
+
+To check the current status of a release, see the [Version Archive](../download_list.mdx).
 
 ## Stable releases
 
@@ -61,7 +76,7 @@ RC releases are useful when:
 
 ## Release branches and the Update OS tool
 
-In the WebGUI, open ***Tools -> Update OS*** or use **Check for Update** from the top-right menu.
+In the WebGUI, open **_Tools -> Update OS_** or use **Check for Update** from the top-right menu.
 
 The Update OS tool shows updates for the release branch your server is already using. To change release branches, open the top-right account menu and choose **Manage Unraid.net Account** to manage the server in the [Unraid account app](../../unraid-account/server-management.mdx). You cannot switch release branches directly from inside the OS.
 
@@ -77,7 +92,8 @@ Your license remains valid even if your update eligibility expires. Update eligi
 For pre-releases:
 
 - Beta and RC versions are for testing and may contain bugs.
-- Support for a pre-release ends when the corresponding stable version is released.
+- Public beta and RC versions count when identifying the current public minor series.
+- Support for a specific pre-release build ends when it is superseded by a newer pre-release or the corresponding stable release.
 - Your license must be eligible for OS updates on the stable release date to receive that stable version.
 - If your update eligibility expires before the stable release, you must extend your license to upgrade to that stable version or roll back to a supported stable version that your license allows.
 
@@ -100,7 +116,7 @@ Good feedback helps turn beta and RC builds into better stable releases and help
 
 - The exact Unraid OS version.
 - Whether the issue started after updating.
-- Diagnostics from ***Tools -> Diagnostics***.
+- Diagnostics from **_Tools -> Diagnostics_**.
 - Steps to reproduce the issue.
 - Any relevant plugin, Docker, VM, network, or storage configuration details.
 

--- a/src/components/VersionsTable.tsx
+++ b/src/components/VersionsTable.tsx
@@ -19,13 +19,30 @@ type RowStatus = "Supported" | "Security updates" | "Superseded" | "EOL";
 const minorOf = (version: string): Minor =>
   version.split(".").slice(0, 2).join(".") as Minor;
 
-const parseVersion = (version: string): number[] =>
-  version.split(/[-.]/).map((part) => {
-    if (part === "beta") return -2;
-    if (part === "rc") return -1;
-    const parsed = Number.parseInt(part, 10);
-    return Number.isNaN(parsed) ? 0 : parsed;
-  });
+const parseVersion = (version: string): number[] => {
+  const parts: number[] = [];
+
+  for (const rawPart of version.split(/[-.]/)) {
+    const part = rawPart.toLowerCase();
+    const betaMatch = part.match(/^beta(\d+)$/);
+    const rcMatch = part.match(/^rc(\d+)$/);
+
+    if (part === "beta") {
+      parts.push(-2);
+    } else if (part === "rc") {
+      parts.push(-1);
+    } else if (betaMatch) {
+      parts.push(-2, Number.parseInt(betaMatch[1], 10));
+    } else if (rcMatch) {
+      parts.push(-1, Number.parseInt(rcMatch[1], 10));
+    } else {
+      const parsed = Number.parseInt(part, 10);
+      parts.push(Number.isNaN(parsed) ? 0 : parsed);
+    }
+  }
+
+  return parts;
+};
 
 const compareVersions = (a: string, b: string) => {
   const aParts = parseVersion(a);

--- a/src/components/VersionsTable.tsx
+++ b/src/components/VersionsTable.tsx
@@ -1,704 +1,253 @@
-/* src/components/VersionsTable.tsx
-   
-   PURPOSE: Automatically displays Unraid release versions in categorized tables
-   - Fetches live data from https://releases.unraid.net/json
-   - Auto-categorizes releases: Stable (current minor), Previous (last minor), Legacy (older)
-   - No manual updates needed when new versions are released
-   
-   ================================================================================
-   COMPREHENSIVE MAINTENANCE GUIDE FOR DOCUMENTATION MAINTAINERS
-   ================================================================================
-   
-   WHEN TO UPDATE: Update this content when a NEW MAJOR VERSION is released (e.g., 7.2.0, 8.0.0, etc.)
-   
-   STEP-BY-STEP UPDATE PROCESS:
-   
-   Step 1: Copy "stable" → "previous"
-   - Find the supportPolicies.stable section below
-   - Copy the entire content (title, description, and all details)
-   - Paste it into supportPolicies.previous
-   - Update any version references (e.g., change "7.1.x" to "7.0.x" if moving from 7.1.x to 7.2.x)
-   
-   Step 2: Copy "previous" → "legacy"
-   - Find the supportPolicies.previous section
-   - Copy the entire content
-   - Paste it into supportPolicies.legacy
-   - Update version references and dates as needed
-   
-   Step 3: Update "stable" with new version info
-   - Update the title and description for the new version
-   - Update all version references in the details
-   - Update dates and license eligibility information
-   - Update kernel and feature information
-   
-   Step 4: Update "upcoming" section
-   - Remove items that have become current stable releases
-   - Add new upcoming versions
-   - Update target dates and feature lists
-   
-   Step 5: Update "Future Release Information" section
-   - Update the version number mentioned in the text
-   - Update any other version-specific references
-   
-   EXAMPLE TRANSITION: From 7.1.x to 7.2.x
-   
-   Before (Current State):
-   - stable: 7.1.x info
-   - previous: 7.0.x info
-   - legacy: 6.x series info
-   
-   After (New State):
-   - stable: 7.2.x info (new)
-   - previous: 7.1.x info (was stable)
-   - legacy: 7.0.x info (was previous)
-   
-   WHAT TO UPDATE IN EACH SECTION:
-   
-   Stable (Current Release):
-   - Version numbers (e.g., "7.2.x", "7.2.0")
-   - Kernel information (e.g., "Linux 6.12 LTS")
-   - License eligibility dates
-   - Bug fix and security update version references
-   - Feature descriptions
-   
-   Previous Release:
-   - Version numbers (e.g., "7.1.x", "7.1.0")
-   - Security update version references
-   - Any version-specific details
-   
-   Legacy (EOL):
-   - Version numbers in description
-   - Any version-specific details
-   
-   Upcoming Features:
-   - Version numbers
-   - Target dates
-   - Feature lists
-   - Remove items that become current
-   
-   IMPORTANT NOTES:
-   - Keep the structure: Don't change the object names (stable, previous, legacy)
-   - Update all references: Make sure version numbers are consistent throughout
-   - Test the page: After making changes, verify the page displays correctly
-   - Backup: Consider backing up the file before making major changes
-   
-   QUICK REFERENCE COMMANDS:
-   - Copy: Ctrl+C (Windows) or Cmd+C (Mac)
-   - Paste: Ctrl+V (Windows) or Cmd+V (Mac)
-   - Select All: Ctrl+A (Windows) or Cmd+A (Mac)
-   - Find: Ctrl+F (Windows) or Cmd+F (Mac)
-   - Replace: Ctrl+H (Windows) or Cmd+H (Mac)
-   
-   MAINTENANCE CHECKLIST:
-   - [ ] Copied stable → previous
-   - [ ] Copied previous → legacy
-   - [ ] Updated stable with new version info
-   - [ ] Updated upcoming features
-   - [ ] Updated future release information
-   - [ ] Verified all version references are consistent
-   - [ ] Tested the page displays correctly
-   
-   NEED HELP?
-   - Check that all brackets {} and quotes "" are properly matched
-   - Verify that commas separate all items in arrays and objects
-   - Ensure version numbers are consistent throughout the file
-   - Test the page after making changes
-   
-   ================================================================================
-   WHAT YOU CAN UPDATE (NON-VERSION RELATED):
-   ================================================================================
-   1. The "What's Next" section below (add/remove upcoming features)
-   2. Category names if you want different terminology
-   3. Styling colors if you want different appearance
-   4. Support policy information for each version category
-   
-   ================================================================================
-*/
-
 import BrowserOnly from "@docusaurus/BrowserOnly";
-import React, {useEffect, useState} from "react";
-import {useColorMode} from "@docusaurus/theme-common";
+import { useColorMode } from "@docusaurus/theme-common";
+import React, { useEffect, useState } from "react";
 
 type Release = {
-  version: string;           
+  version: string;
   date: string;
-  basefile: string;
-  url: string;
-  md5: string;
+  basefile?: string;
+  url?: string;
+  md5?: string;
   changelog_pretty: string;
+  downloadable?: boolean;
 };
 
 type Minor = `${number}.${number}`;
+type StatusFilter = "supported" | "eol";
+type RowStatus = "Supported" | "Security updates" | "Superseded" | "EOL";
 
-/* 
-   ================================================================================
-   EDITABLE SECTION: Support Policy Information
-   ================================================================================
-   
-   ⚠️  CRITICAL: This is the main section that needs updating when new versions are released!
-   
-   UPDATE PROCESS (when new major version like 7.2.0 is released):
-   
-   1. COPY "stable" → "previous" (copy the entire stable object)
-   2. COPY "previous" → "legacy" (copy the entire previous object)  
-   3. UPDATE "stable" with new version information
-   4. UPDATE "upcoming" section for next version
-   5. UPDATE dates and version references
-   
-   Example transition from 7.1.x to 7.2.x:
-   - stable: 7.2.x info (new)
-   - previous: 7.1.x info (was stable)
-   - legacy: 7.0.x info (was previous)
-   
-   FORMATTING IS AUTOMATIC - just type plain text!
-   No HTML tags needed - just update the text in quotes!
-   
-   ================================================================================
- */
-const supportPolicies = {
-  stable: {
-    title: "Current/Stable Release",
-    description: "The 7.2.x series is our current/stable release",
-    details: [
-      { type: "header", content: "Kernel: Linux 6.12 LTS" },
-      { type: "header", content: "ZFS Version: OpenZFS 2.3.x" },
-      { type: "text", content: "Primary features are detailed in the <a href='/unraid-os/release-notes/7.2.0'>7.2.0 Release Notes</a>." },
-      { type: "header", content: "License Information:" },
-      { type: "bullet", content: "If your license extension expires on or after 2025-10-29, you are eligible for all releases in this series." },
-      { type: "header", content: "Update Recommendations:" },
-      { type: "bullet", content: "If you are experiencing issues with earlier releases, we recommend updating to the latest release as it may resolve the issue." },
-      { type: "header", content: "Release Status:" },
-      { type: "bullet", content: "This series is feature complete; no new features are expected." },
-      { type: "bullet", content: "Bug fixes will be backported to 7.2.x as appropriate until the release of 7.3.0." },
-      { type: "bullet", content: "Security updates will be provided for 7.2.x as appropriate until the release of 7.4.0." },
-      { type: "header", content: "Future Releases:" },
-      { type: "bullet", content: "Additional public beta/RC releases for 7.2.x are unlikely, but any announcements will be made in the <a href='https://forums.unraid.net/forum/7-announcements/'>main forum</a>." },
-      { type: "bullet", content: "New stable releases of 7.2.x will be announced in the forum." }
-    ]
-  },
-  previous: {
-    title: "Previous Release",
-    description: "The 7.1.x series is no longer being actively developed",
-    details: [
-      { type: "header", content: "Kernel: Linux 6.12 LTS" },
-      { type: "header", content: "ZFS Version: OpenZFS 2.3.x" },
-      { type: "text", content: "Primary features are detailed in the <a href='/unraid-os/release-notes/7.1.0'>7.1.0 Release Notes</a>." },
-      { type: "header", content: "License Information:" },
-      { type: "bullet", content: "If your license extension expires on or after 2025-05-05, you are eligible for all releases in this series." },
-      { type: "header", content: "Update Recommendations:" },
-      { type: "bullet", content: "Until Unraid 7.3.0 is released, 7.1.x will only receive updates for serious security issues, with no bug fixes or new features." },
-      { type: "bullet", content: "All users are encouraged to upgrade to the current release." },
-      { type: "header", content: "Future Releases:" },
-      { type: "bullet", content: "Additional public beta/RC releases for 7.1.x are unlikely, but any announcements will be made in the <a href='https://forums.unraid.net/forum/7-announcements/'>main forum</a>." },
-      { type: "bullet", content: "New stable releases of 7.1.x will be announced in the forum." }
-    ]
-  },
-  previousUnused: {
-    title: "Previous Release",
-    description: "The 7.0.x series is no longer being actively developed",
-    details: [
-      { type: "header", content: "Kernel: Linux 6.6 LTS" },
-      { type: "text", content: "Primary features are detailed in the <a href='/unraid-os/release-notes/7.0.0'>7.0.0 Release Notes</a>." },
-      { type: "header", content: "License Information:" },
-      { type: "bullet", content: "If your license extension expires on or after 2025-01-09, you are eligible for all releases in this series." },
-      { type: "header", content: "Update Recommendations:" },
-      { type: "bullet", content: "Until Unraid 7.2.0 is released, 7.0.x will only receive updates for serious security issues, with no bug fixes or new features." },
-      { type: "bullet", content: "All users are encouraged to upgrade to the current release." },
-      { type: "header", content: "Future Releases:" },
-      { type: "bullet", content: "Additional public beta/RC releases for 7.0.x are unlikely, but any announcements will be made in the <a href='https://forums.unraid.net/forum/7-announcements/'>main forum</a>." },
-      { type: "bullet", content: "Any new stable releases of 7.0.x will be announced in the forum." }
-    ]
-  },
-  legacy: {
-    title: "End of Life (EOL) Releases",
-    description: "Unraid 7.0.x, 6.12.x, 6.11.x, 6.10.x, and earlier have reached End of Life (EOL)",
-    details: [
-      { type: "header", content: "Support Status:" },
-      { type: "bullet", content: "These versions have reached End of Life (EOL) and are not supported." },
-      { type: "bullet", content: "No further updates will be provided." },
-      { type: "bullet", content: "Users are encouraged to upgrade to the current release as soon as possible." }
-    ]
+const minorOf = (version: string): Minor =>
+  version.split(".").slice(0, 2).join(".") as Minor;
+
+const parseVersion = (version: string): number[] =>
+  version.split(/[-.]/).map((part) => {
+    if (part === "beta") return -2;
+    if (part === "rc") return -1;
+    const parsed = Number.parseInt(part, 10);
+    return Number.isNaN(parsed) ? 0 : parsed;
+  });
+
+const compareVersions = (a: string, b: string) => {
+  const aParts = parseVersion(a);
+  const bParts = parseVersion(b);
+  const length = Math.max(aParts.length, bParts.length);
+
+  for (let index = 0; index < length; index += 1) {
+    const diff = (bParts[index] ?? 0) - (aParts[index] ?? 0);
+    if (diff !== 0) return diff;
   }
+
+  return 0;
 };
 
-/* 
-   ================================================================================
-   EDITABLE SECTION: Upcoming Features
-   ================================================================================
-   
-   ⚠️  UPDATE THIS SECTION when planning new releases!
-   
-   - Add new upcoming versions with target dates and feature highlights
-   - Remove items when they become current stable releases
-   - Update version numbers, dates, and feature lists as needed
-   
-   ================================================================================
- */
-const upcoming = [
-  {
-    version: "7.3.x",
-    status: "Currently in development. When a beta is available, it will be announced in the <a href='https://forums.unraid.net/forum/7-announcements/'>main forum</a>.",
-    highlights: [],
-  },
-  // Add more upcoming versions here if needed:
-  // {
-  //   version: "8.0.x",
-  //   status: "Planning phase",
-  //   highlights: [],
-  // },
-];
+const getLatestRelease = (releases: Release[]) =>
+  [...releases].sort((a, b) => compareVersions(a.version, b.version))[0];
 
+const isDownloadableRelease = (
+  release: Release,
+): release is Release & { basefile: string; url: string; md5: string } =>
+  release.downloadable !== false &&
+  Boolean(release.basefile && release.url && release.md5);
 
-
-
-
-/* 
-   SUPPORT POLICY INFORMATION
-   This section explains what users can expect for each version category
-   The information is dynamically generated based on detected versions
-*/
-const getSupportInfo = (currentMinor: string, previousMinor: string) => ({
-  stable: {
-    title: "Current/Stable Release",
-    description: `The ${currentMinor}.x series is our current/stable release`,
-    details: [
-      `The primary features are listed in the ${currentMinor}.0 release notes`,
-      "This series uses the Linux 6.12 LTS kernel with OpenZFS 2.3.x",
-      "If your license extension expires on or after 2025-05-05 you are eligible for all releases in this series",
-      "If you are having issues with earlier releases, we generally recommend updating to the latest release as it may resolve the issue",
-      "While there may be additional releases in this series, no new features are expected; this series is feature complete",
-      `Until ${getNextMinor(currentMinor)}.0 is released we will backport bug fixes to ${currentMinor}.x as appropriate`,
-      `Until ${getNextMinor(getNextMinor(currentMinor))}.0 is released we will provide security updates to ${currentMinor}.x as appropriate`,
-      `There probably won't be additional public beta/rc releases for ${currentMinor}.x, but if there are they will be announced in the <a href='https://forums.unraid.net/forum/7-announcements/'>main forum</a>`,
-      `New stable releases of ${currentMinor}.x will be announced in the forum`
-    ]
-  },
-  previous: {
-    title: "Previous Release",
-    description: `The ${previousMinor}.x series is no longer being actively developed`,
-    details: [
-      `The primary features are listed in the ${previousMinor}.0 release notes`,
-      "This series uses the Linux 6.6 LTS kernel",
-      "If your license extension expires on or after 2025-01-09 you are eligible for all releases in this series",
-      `Until Unraid ${getNextMinor(currentMinor)}.0 is released, ${previousMinor}.x will get updates for serious security issues only, no bug fixes or new features`,
-      "All users are encouraged to upgrade to the current release",
-      "For more information about license extensions, see the <a href='../docs/unraid-os/troubleshooting/licensing-faq.md#no-extension'>licensing FAQ</a>",
-      `There probably won't be additional public beta/rc releases for ${previousMinor}.x, but if there are they will be announced in the <a href='https://forums.unraid.net/forum/7-announcements/'>main forum</a>`,
-      `Any new stable releases of ${previousMinor}.x will be announced in the forum`
-    ]
-  },
-  legacy: {
-    title: "End of Life (EOL) Releases",
-    description: `Unraid ${previousMinor}.x and earlier have reached End of Life (EOL)`,
-    details: [
-      "They are not supported and will receive no further updates",
-      "Users should upgrade to the current release ASAP"
-    ]
-  }
-});
-
-// Helper function to get the next minor version
-const getNextMinor = (minor: string): string => {
-  const [major, minorNum] = minor.split(".");
-  return `${major}.${parseInt(minorNum) + 1}`;
-};
-
-/* 
-   AUTOMATIC FUNCTIONS: These handle version categorization
-   No editing needed - they automatically detect the newest versions
-*/
-const minorOf = (v: string): Minor =>
-  v.split(".").slice(0, 2).join(".") as Minor;
-
-const badge = (label: "Stable" | "Previous" | "Legacy") => {
+const badge = (label: RowStatus) => {
   const cls =
-    label === "Stable"
-      ? "badge--success"      // Green badge
-      : label === "Previous"
-      ? "badge--primary"      // Blue badge  
-      : "badge--secondary";   // Gray badge
+    label === "Supported" || label === "Security updates"
+      ? "badge--success"
+      : label === "EOL"
+        ? "badge--secondary"
+        : "badge--warning";
+
   return <span className={`badge ${cls}`}>{label}</span>;
 };
 
-/* 
-   CHANGELOG CLEANER: Removes navigation elements from release notes
-   This ensures only the actual release content shows up in the expandable sections
-*/
-const stripChrome = (html: string) => {
-  const dom = new DOMParser().parseFromString(html, "text/html");
-  
-  // Remove navigation and layout elements
-  dom.querySelectorAll(
-    "nav, .navbar, .sidebar, .breadcrumbs, .theme-doc-breadcrumbs," +
-      ".theme-doc-toc-desktop, .theme-doc-toc-mobile, .pagination-nav," +
-      "header, footer, .header, .footer"
-  ).forEach((el) => el.remove());
-  
-  // Clean up any problematic CSS that might cause alignment issues
-  dom.querySelectorAll("*").forEach((el) => {
-    if (el instanceof HTMLElement && el.style) {
-      // Remove positioning that might cause cutoff
-      el.style.position = "";
-      el.style.left = "";
-      el.style.right = "";
-      el.style.marginLeft = "";
-      el.style.marginRight = "";
-      el.style.paddingLeft = "";
-      el.style.paddingRight = "";
-      el.style.width = "";
-      el.style.maxWidth = "";
-      el.style.overflow = "";
-      el.style.textAlign = "";
-      el.style.float = "";
-      el.style.display = "";
-    }
-  });
-  
-  const main = dom.querySelector("main .markdown, main article, main") ?? dom.body;
-  const content = main.innerHTML;
-  const css = `
-    <style>
-      .release-notes{width:100%;max-width:100%;margin:0;padding:0;box-sizing:border-box;text-align:left;display:block;min-width:100%}
-      .release-notes *{box-sizing:border-box;max-width:100%;margin-left:0!important;left:auto!important;right:auto!important;float:none!important;position:static!important;width:auto!important;min-width:0!important}
-      .release-notes article{margin:0!important;padding:0!important;width:100%!important;max-width:100%!important;min-width:100%!important;display:block!important;box-sizing:border-box!important}
-      .release-notes article *{width:100%!important;max-width:100%!important;min-width:0!important;box-sizing:border-box!important}
-      .release-notes h1,.release-notes h2,.release-notes h3,.release-notes h4,.release-notes h5,.release-notes h6{margin:0 0 0.5rem 0;padding:0;text-align:left;width:100%!important;max-width:100%!important;min-width:0!important}
-      .release-notes p{margin:0 0 0.5rem 0;padding:0;text-align:left;width:100%!important;max-width:100%!important;min-width:0!important}
-      .release-notes ul,.release-notes ol{margin:0 0 0.5rem 0;padding-left:1.5rem;text-align:left;width:100%!important;max-width:100%!important;min-width:0!important}
-      .release-notes li{margin:0 0 0.25rem 0;padding:0;text-align:left;width:100%!important;max-width:100%!important;min-width:0!important}
-      .release-notes .hash-link,.release-notes a.anchor,.release-notes .header-anchor{display:none}
-      .release-notes table{width:100%;max-width:100%;margin:0 0 0.5rem 0;min-width:0}
-      .release-notes pre{max-width:100%;overflow-x:auto;white-space:pre-wrap;word-wrap:break-word;width:100%!important;min-width:0!important}
-      .release-notes blockquote{margin:0 0 0.5rem 0;padding:0.5rem 1rem;border-left:3px solid #ccc;width:100%!important;min-width:0!important}
-      .release-notes code{background:#f5f5f5;padding:0.2rem 0.4rem;border-radius:3px;font-size:0.9em}
-      .release-notes img{max-width:100%;height:auto;min-width:0}
-      .release-notes hr{margin:1rem 0;border:none;border-top:1px solid #ddd;width:100%!important;min-width:0!important}
-      .release-notes div{width:100%!important;max-width:100%!important;min-width:100%!important}
-      .release-notes section{width:100%!important;max-width:100%!important;min-width:100%!important}
-      @media (max-width: 768px) {
-        .release-notes{width:100%;max-width:100%;min-width:100%}
-        .release-notes *{width:100%!important;max-width:100%!important;min-width:0!important}
-      }
-    </style>`;
-  return `${css}<div class="release-notes">${content}</div>`;
-};
+const getSupportPolicies = (currentMinor?: Minor, previousMinor?: Minor) => ({
+  supported: {
+    title: "Supported releases",
+    description:
+      currentMinor && previousMinor
+        ? `Unraid ${currentMinor}.x is the current public minor series. Unraid ${previousMinor}.x receives security updates as appropriate.`
+        : "Loading supported public minor series.",
+    details: [
+      "The latest patch or pre-release build in the current public minor series is supported.",
+      "The latest patch in the previous public minor series receives security updates as appropriate.",
+      "Older patch or pre-release builds in supported series are kept in the archive, but are superseded by the latest available build for that series.",
+      "Production systems should normally use the latest stable build, even when a newer beta or RC is public.",
+    ],
+  },
+  eol: {
+    title: "End of Life (EOL) releases",
+    description:
+      "Older public minor series have reached End of Life and are kept here only for archive access.",
+    details: [
+      "EOL releases are not supported and no longer include bug fixes or security updates.",
+      "If you are running an EOL release, review the supported release options before planning an update.",
+      "See the licensing FAQ and release types page for the full support policy.",
+    ],
+  },
+});
 
-/* 
-   MAIN COMPONENT: Handles the entire version table display
-   This automatically updates when new releases are published
-*/
 function Viewer() {
   const [releases, setReleases] = useState<Release[]>([]);
-  const [open, setOpen] = useState<string | null>(null);
-  const [logs, setLogs] = useState<Record<string, string>>({});
-  const [filter, setFilter] =
-    useState<"stable" | "previous" | "legacy">("stable");
-  const {colorMode} = useColorMode();
+  const [filter, setFilter] = useState<StatusFilter>("supported");
+  const { colorMode } = useColorMode();
 
-  /* 
-     DATA FETCHING: Gets latest release info automatically
-     This runs every time someone visits the page
-  */
   useEffect(() => {
-    fetch("https://releases.unraid.net/json")
-      .then((r) => r.json())
-      .then((d: Release[]) => setReleases(d))
+    fetch("https://releases.unraid.net/json?includePublic=1")
+      .then((response) => response.json())
+      .then((data: Release[]) =>
+        setReleases(
+          [...data].sort((a, b) => compareVersions(a.version, b.version)),
+        ),
+      )
       .catch(console.error);
   }, []);
 
-  /* 
-     AUTOMATIC CATEGORIZATION: Sorts versions into Stable/Previous/Legacy
-     - Stable: All versions in the newest minor release (e.g., all 7.1.x)
-     - Previous: All versions in the second-newest minor (e.g., all 7.0.x)  
-     - Legacy: Everything older than that
-     
-     This automatically updates when new minor versions are released
-  */
-  const minors = Array.from(new Set(releases.map((r) => minorOf(r.version))))
-    .sort((a, b) => (b > a ? 1 : -1));
-  const currentMinor = minors[0];   // e.g., "7.1"
-  const previousMinor = minors[1];  // e.g., "7.0"
+  const minors = Array.from(
+    new Set(releases.map((release) => minorOf(release.version))),
+  ).sort((a, b) => compareVersions(`${a}.0`, `${b}.0`));
+  const currentMinor = minors[0];
+  const previousMinor = minors[1];
 
   const groups = {
-    stable:   releases.filter((r) => minorOf(r.version) === currentMinor),
-    previous: releases.filter((r) => minorOf(r.version) === previousMinor),
-    legacy:   releases.filter(
-      (r) => ![currentMinor, previousMinor].includes(minorOf(r.version))
+    current: releases.filter(
+      (release) => minorOf(release.version) === currentMinor,
+    ),
+    previous: releases.filter(
+      (release) => minorOf(release.version) === previousMinor,
+    ),
+    supported: releases.filter((release) =>
+      [currentMinor, previousMinor].includes(minorOf(release.version)),
+    ),
+    eol: releases.filter(
+      (release) =>
+        ![currentMinor, previousMinor].includes(minorOf(release.version)),
     ),
   };
 
-  /* 
-     CHANGELOG DISPLAY: Loads release notes when user clicks "Show notes"
-     Each changelog is fetched only once and cached for performance
-  */
-  const toggle = async (rel: Release) => {
-    if (open === rel.version) return setOpen(null);
-    if (!logs[rel.version]) {
-      try {
-        const raw = await (await fetch(rel.changelog_pretty)).text();
-        setLogs((p) => ({...p, [rel.version]: stripChrome(raw)}));
-      } catch {
-        setLogs((p) => ({
-          ...p,
-          [rel.version]: "<em>Unable to load changelog.</em>",
-        }));
-      }
+  const supportPolicies = getSupportPolicies(currentMinor, previousMinor);
+
+  const latestCurrentRelease = getLatestRelease(groups.current);
+  const latestPreviousRelease = getLatestRelease(groups.previous);
+
+  const getRowStatus = (release: Release, statusFilter: StatusFilter) => {
+    const releaseMinor = minorOf(release.version);
+
+    if (statusFilter === "eol") return "EOL";
+    if (releaseMinor === currentMinor) {
+      return latestCurrentRelease?.version === release.version
+        ? "Supported"
+        : "Superseded";
     }
-    setOpen(rel.version);
+    if (releaseMinor === previousMinor) {
+      return latestPreviousRelease?.version === release.version
+        ? "Security updates"
+        : "Superseded";
+    }
+
+    return "EOL";
   };
 
-  /* 
-     THEME SUPPORT: Automatically matches your site's dark/light mode
-     The changelog boxes will match whatever theme the user has selected
-  */
-  const noteBox = {
-    background: colorMode === "dark" ? "#1b1b1d" : "#f9f9f9",
-    color:       colorMode === "dark" ? "#e3e3e3" : "#333",
-    border:      `1px solid ${colorMode === "dark" ? "#444" : "#ddd"}`,
-    borderRadius: "4px",
-    padding: "1.5rem",
-    fontSize: "0.9rem",
-    lineHeight: 1.6,
-    overflow: "visible",
-    wordWrap: "break-word",
-    width: "100%",
-    maxWidth: "100%",
-    boxSizing: "border-box",
-    textAlign: "left",
-  } as const;
+  const renderRows = (list: Release[], statusFilter: StatusFilter) =>
+    list.map((release) => {
+      const rowStatus = getRowStatus(release, statusFilter);
+      const canDownload = isDownloadableRelease(release);
 
-  /* 
-     TABLE ROW GENERATOR: Creates the actual table rows for each release
-     This handles the download links, version info, and expandable changelogs
-  */
-  const renderRows = (list: Release[], label: "Stable"|"Previous"|"Legacy") =>
-    list.map((rel) => (
-      <React.Fragment key={rel.version}>
-        <tr>
-          <td>{badge(label)}</td>
-          <td>{rel.version}</td>
-          <td>{rel.date}</td>
-          <td><a download href={rel.url}>{rel.basefile}</a></td>
-          <td style={{fontSize:"0.75rem"}}>{rel.md5}</td>
-          <td>
-            <button
-              className="button button--link button--sm"
-              onClick={() => toggle(rel)}
-            >
-              {open === rel.version ? "Hide" : "Show"} notes
-            </button>
-          </td>
-        </tr>
-        {open === rel.version && (
+      return (
+        <React.Fragment key={release.version}>
           <tr>
-            <td colSpan={6} style={{
-              padding: "0",
-              border: "none",
-              backgroundColor: "transparent",
-              textAlign: "center",
-              width: "100%",
-              maxWidth: "100%",
-              minWidth: "100%"
-            }}>
-              <div style={{
-                ...noteBox,
-                width: "100%",
-                maxWidth: "100%",
-                minWidth: "100%",
-                margin: "0",
-                padding: "1.5rem",
-                boxSizing: "border-box"
-              }}>
-                <div 
-                  style={{
-                    margin: "0",
-                    padding: "0",
-                    width: "100%",
-                    maxWidth: "100%",
-                    minWidth: "100%",
-                    boxSizing: "border-box",
-                  }}
-                  dangerouslySetInnerHTML={{__html: logs[rel.version] ?? "Loading…"}}
-                />
-              </div>
+            <td>{badge(rowStatus)}</td>
+            <td>{release.version}</td>
+            <td>{release.date}</td>
+            <td>
+              {canDownload ? (
+                <a download href={release.url}>
+                  {release.basefile}
+                </a>
+              ) : (
+                "Use account.unraid.net / USB Creator to download prereleases"
+              )}
+            </td>
+            <td style={{ fontSize: "0.75rem" }}>
+              {canDownload ? release.md5 : "N/A"}
+            </td>
+            <td>
+              <a href={release.changelog_pretty}>Release notes</a>
             </td>
           </tr>
-        )}
-      </React.Fragment>
-    ));
+        </React.Fragment>
+      );
+    });
 
   return (
     <>
-
-
-      {/* 
-          FILTER BUTTONS
-          Users can click these to show only Stable, Previous, or Legacy releases
-          You can rename these categories by changing the text below
-      */}
-      {(["stable","previous","legacy"] as const).map((k) => (
+      {(["supported", "eol"] as const).map((key) => (
         <button
-          key={k}
+          key={key}
           className={`button button--sm ${
-            filter === k ? "button--primary" : "button--secondary"
+            filter === key ? "button--primary" : "button--secondary"
           }`}
-          style={{marginRight:"0.5rem"}}
-          onClick={() => {setFilter(k); setOpen(null);}}
+          style={{ marginRight: "0.5rem" }}
+          onClick={() => {
+            setFilter(key);
+          }}
         >
-          {k === "stable" ? "Stable"           
-           : k === "previous" ? "Previous"       
-           : "Legacy"}                         
+          {key === "supported" ? "Supported" : "EOL"}
         </button>
       ))}
 
-      {/* 
-          SUPPORT POLICY INFORMATION
-          Shows different support information based on the selected tab
-          This helps users understand what to expect for each version category
-      */}
-      <div style={{
-        background: colorMode === "dark" ? "#1b1b1d" : "#f9f9f9",
-        border: `1px solid ${colorMode === "dark" ? "#444" : "#ddd"}`,
-        borderRadius: "8px",
-        padding: "1.5rem",
-        marginTop: "1.5rem",
-        marginBottom: "1.5rem"
-      }}>
-        <h3 style={{marginTop: 0, marginBottom: "1rem"}}>
-          {supportPolicies[filter].title}
-        </h3>
-        <p style={{marginBottom: "1rem", fontWeight: "500"}}>
-          {supportPolicies[filter].description}
-        </p>
-        <ul style={{margin: 0, paddingLeft: "0"}}>
-          {supportPolicies[filter].details.map((detail, index) => {
-            if (detail.type === "bullet") {
-              return (
-                <li key={index} style={{
-                  marginBottom: "0.5rem",
-                  listStyle: "none",
-                  position: "relative",
-                  paddingLeft: "1.5rem"
-                }}>
-                  <span style={{
-                    position: "absolute",
-                    left: "0",
-                    top: "0"
-                  }}>•</span>
-                  <span dangerouslySetInnerHTML={{__html: detail.content}} />
-                </li>
-              );
-            } else if (detail.type === "header") {
-              return (
-                <div key={index} style={{
-                  marginTop: index > 0 ? "1.5rem" : "0",
-                  marginBottom: "0.75rem",
-                  paddingLeft: "0",
-                  fontWeight: "600",
-                  fontSize: "1rem"
-                }}>
-                  {detail.content}
-                </div>
-              );
-            } else {
-              return (
-                <div key={index} style={{
-                  marginBottom: "0.5rem",
-                  paddingLeft: "0"
-                }}>
-                  <span dangerouslySetInnerHTML={{__html: detail.content}} />
-                </div>
-              );
-            }
-          })}
-        </ul>
-      </div>
-
-      {/* 
-          MAIN RELEASES TABLE
-          This automatically populates with data from releases.unraid.net
-          No manual updates needed when new versions are published
-      */}
-      <table className="table" style={{
-        marginTop:"1rem",
-        width: "100%",
-        maxWidth: "100%",
-        minWidth: "100%"
-      }}>
-        <thead>
-          <tr>
-            <th style={{width: "12%"}}>Status</th>
-            <th style={{width: "15%"}}>Version</th>
-            <th style={{width: "15%"}}>Date</th>
-            <th style={{width: "35%"}}>Download</th>
-            <th style={{width: "18%"}}>MD5</th>
-            <th style={{width: "5%"}}></th>
-          </tr>
-        </thead>
-        <tbody>
-          {renderRows(groups[filter], filter === "stable" ? "Stable"
-                                 : filter === "previous" ? "Previous"
-                                 : "Legacy")}
-        </tbody>
-      </table>
-
-      {/* 
-          UPCOMING FEATURES SECTION
-          Edit the 'upcoming' array at the top of this file to modify this section
-          You can add, remove, or update items as your roadmap changes
-      */}
-      {upcoming.length > 0 && (
-        <>
-          <h2 style={{marginTop: "2rem", marginBottom: "1rem"}}>What's next?</h2>
-          {upcoming.map((u) => (
-            <div key={u.version} style={{marginBottom:"1.5rem"}}>
-              <h3>{u.version}</h3>
-              <p dangerouslySetInnerHTML={{__html: u.status}} />
-              {u.highlights.length > 0 && (
-                <ul>{u.highlights.map((h) => <li key={h}>{h}</li>)}</ul>
-              )}
-            </div>
-          ))}
-        </>
-      )}
-
-      {/* 
-          FUTURE RELEASE INFORMATION
-          Collapsible section with general information about beta/RC testing
-          This can be expanded/collapsed by users
-      */}
-      <div style={{marginTop:"2rem"}}>
-        <details style={{
+      <div
+        style={{
           background: colorMode === "dark" ? "#1b1b1d" : "#f9f9f9",
           border: `1px solid ${colorMode === "dark" ? "#444" : "#ddd"}`,
           borderRadius: "8px",
-          padding: "1rem"
-        }}>
-          <summary style={{
-            cursor: "pointer",
-            fontWeight: "600",
-            fontSize: "1.1rem",
-            marginBottom: "0.5rem"
-          }}>
-            Future release information
-          </summary>
-          <div style={{marginTop: "1rem"}}>
-            <p>Details to come!</p>
-          </div>
-        </details>
+          padding: "1.5rem",
+          marginTop: "1.5rem",
+          marginBottom: "1.5rem",
+        }}
+      >
+        <h3 style={{ marginTop: 0, marginBottom: "1rem" }}>
+          {supportPolicies[filter].title}
+        </h3>
+        <p style={{ marginBottom: "1rem", fontWeight: "500" }}>
+          {supportPolicies[filter].description}
+        </p>
+        <ul style={{ margin: 0, paddingLeft: "1.25rem" }}>
+          {supportPolicies[filter].details.map((detail) => (
+            <li key={detail} style={{ marginBottom: "0.5rem" }}>
+              {detail}
+            </li>
+          ))}
+        </ul>
       </div>
+
+      <table
+        className="table"
+        style={{
+          marginTop: "1rem",
+          width: "100%",
+          maxWidth: "100%",
+          minWidth: "100%",
+        }}
+      >
+        <thead>
+          <tr>
+            <th style={{ width: "12%" }}>Status</th>
+            <th style={{ width: "15%" }}>Version</th>
+            <th style={{ width: "15%" }}>Date</th>
+            <th style={{ width: "35%" }}>Download</th>
+            <th style={{ width: "18%" }}>MD5</th>
+            <th style={{ width: "5%" }}>Changes</th>
+          </tr>
+        </thead>
+        <tbody>{renderRows(groups[filter], filter)}</tbody>
+      </table>
     </>
   );
 }
 
-/* 
-   BROWSER WRAPPER: Ensures this component only runs in the browser
-   This is required for the live data fetching to work properly
-   DO NOT MODIFY this section
-*/
 export function VersionsTable() {
   return (
-    <BrowserOnly fallback={<div>Loading…</div>}>
+    <BrowserOnly fallback={<div>Loading...</div>}>
       {() => <Viewer />}
     </BrowserOnly>
   );


### PR DESCRIPTION
## Summary

- Clarifies the Version Archive so releases are grouped by supported and EOL status.
- Documents how current and previous public minor series are supported in the licensing FAQ and release-types guide.
- Simplifies the versions table to mark supported, security-update, superseded, and EOL releases dynamically.
- Handles compact prerelease tokens such as `rc8` and `beta2` when sorting release versions.
- Fixes the 7.2.7 release-note heading hierarchy that was failing PR lint.

## Validation

- `pnpm exec prettier --check src/components/VersionsTable.tsx docs/unraid-os/release-notes/7.2.7.md`
- `pnpm exec remark docs/unraid-os/release-notes/7.2.7.md --quiet --frail`
- `pnpm run lint:mdx`
- Parser smoke check: final release sorts ahead of `rc8`, `rc8` ahead of `rc1`, and `rc1` ahead of `beta2`.
- `pnpm exec tsc --ignoreDeprecations 6.0` *(fails on existing unrelated type errors in RedirectList, ReleasesList, and theme Layout files)*
- Full build not run locally per repo guidance; GitHub PR Lint passed on commit `75a0d30`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified how releases are grouped by support status, updated licensing-eligibility and upgrade guidance, expanded USB boot-media and troubleshooting instructions, and refined pre-release/support-policy wording and formatting across release, release-types, and licensing FAQ pages.

* **Refactor**
  * Reworked the versions display into a data-driven release table with per-release status badges, clearer download/prerelease guidance, and streamlined supported vs EOL view.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unraid/docs/pull/480?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->