### PR TITLE
fix: responsive embed credentialless attribute

### DIFF
--- a/src/components/ResponsiveEmbed/__tests__/ResponsiveEmbed.test.tsx
+++ b/src/components/ResponsiveEmbed/__tests__/ResponsiveEmbed.test.tsx
@@ -1,0 +1,30 @@
+import { Children, isValidElement, type ReactElement, type ReactNode } from "react";
+import { describe, expect, it } from "vitest";
+
+import ResponsiveEmbed from "../index";
+
+type TestElement = ReactElement<Record<string, unknown> & { children?: ReactNode }>;
+
+function onlyElementChild(element: TestElement): TestElement {
+  const child = Children.only(element.props.children);
+
+  if (isValidElement<Record<string, unknown> & { children?: ReactNode }>(child)) {
+    return child;
+  }
+
+  throw new Error("Expected a React element child.");
+}
+
+describe("ResponsiveEmbed", () => {
+  it("passes credentialless as a string so React renders the iframe attribute", () => {
+    const embed = ResponsiveEmbed({
+      src: "https://www.youtube.com/embed/NMHaMaa8iV0",
+      title: "Internal boot walkthrough",
+    }) as TestElement;
+    const frame = onlyElementChild(embed);
+    const iframe = onlyElementChild(frame);
+
+    expect(iframe.props.credentialless).toBe("");
+    expect(iframe.props.src).toBe("https://www.youtube.com/embed/NMHaMaa8iV0");
+  });
+});

--- a/src/components/ResponsiveEmbed/index.tsx
+++ b/src/components/ResponsiveEmbed/index.tsx
@@ -13,6 +13,13 @@ type ResponsiveEmbedProps = {
   iframeClassName?: string;
 };
 
+const credentiallessIframeProps: Record<string, string> = {
+  // React treats `credentialless` as a non-boolean iframe attribute.
+  // Passing `credentialless` or `{true}` omits it during SSR, which breaks
+  // embeds on pages served with `Cross-Origin-Embedder-Policy: credentialless`.
+  credentialless: "",
+} as const;
+
 export default function ResponsiveEmbed({
   src,
   title,
@@ -38,7 +45,7 @@ export default function ResponsiveEmbed({
     <div className={embedClasses}>
       <div className={frameClasses} style={frameStyle}>
         <iframe
-          credentialless
+          {...credentiallessIframeProps}
           loading="lazy"
           className={iframeClasses}
           src={src}


### PR DESCRIPTION
## Summary
- Restore the forced string form for the `credentialless` iframe attribute in `ResponsiveEmbed`.
- Document why the wrapper must not use the boolean JSX shorthand.
- Add a focused regression test so future cleanup catches this behavior.

## Root cause
PR #407 changed `ResponsiveEmbed` from `{...{ credentialless: "" }}` to the JSX boolean shorthand `credentialless`. React treats `credentialless` as a non-boolean iframe attribute, so `credentialless={true}` is omitted during render. On docs pages served with `Cross-Origin-Embedder-Policy: credentialless`, that omission breaks cross-origin video embeds such as YouTube.

## Validation
- `pnpm exec vitest run src/components/ResponsiveEmbed/__tests__/ResponsiveEmbed.test.tsx`
- `git diff --check`
- `pnpm run build`
- Verified generated `build/unraid-os/getting-started/set-up-unraid/internal-boot-faq/index.html` contains `credentialless=""` on both YouTube iframes.

## Build notes
- Full Docusaurus build completed successfully.
- Build emitted existing warnings for broken links/anchors, localized markdown directives, and HTML minifier diagnostics on unrelated pages.
- `pnpm run typecheck` currently fails before source validation because TypeScript 6 reports the repo's `baseUrl` deprecation. `pnpm exec tsc --noEmit --ignoreDeprecations 6.0 --pretty false` then reports existing unrelated errors in `RedirectList`, `ReleasesList`, and `Layout`, with no errors in `ResponsiveEmbed` after this change.