### PR TITLE
Corrected Linux kernel to 6.18.29-Unraid in release notes

### DIFF
--- a/docs/unraid-os/release-notes/7.3.0.md
+++ b/docs/unraid-os/release-notes/7.3.0.md
@@ -124,7 +124,7 @@ To proactively switch to TPM-based licensing, see [How can I move from flash-bas
 
 ### Linux kernel
 
-- Linux kernel: update to `6.18.28-Unraid`.
+- Linux kernel: update to `6.18.29-Unraid`.
 
 ### Base distro updates
 


### PR DESCRIPTION
The kernel was incorrected listed as 6.18.28. This update fixes the typo.

Before Submitting This PR, Please Ensure You Have Completed The Following:

1. [X] Are internal links to wiki documents using [relative file links](https://docusaurus.io/docs/markdown-features/links)?
2. [X] Are all new documentation files lowercase, with dash separated names (ex. unraid-os.mdx)?
3. [X] Are all assets (images, etc), located in an assets/ subfolder next to the .md/mdx files?
4. [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
5. [X] Is the build succeeding?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Linux kernel version to 6.18.29-Unraid in release notes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unraid/docs/pull/486?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->