### PR TITLE
feat: Add Unraid OS 7.3.1 release notes

### DIFF
--- a/docs/unraid-os/release-notes/7.3.1.md
+++ b/docs/unraid-os/release-notes/7.3.1.md
@@ -1,0 +1,94 @@
+# Release notes · Unraid OS 7.3.1
+
+## Version 7.3.1-rc.0.3
+
+## Version 7.3.1 2026-05-26
+
+This release focuses on security updates, a Linux kernel update, Docker and ZFS updates, storage fixes, WebGUI/system fixes, and base distro package updates.
+
+Recommended for all users, especially those who want the latest security and stability fixes.
+
+## Upgrading
+
+For step-by-step instructions, see [Updating Unraid](/unraid-os/updating-unraid/). Questions about your [license](/unraid-os/troubleshooting/licensing-faq/)?
+
+## Known issues
+
+* No new release-specific known issues are reported for this release. See the [Unraid OS 7.3.0](/unraid-os/release-notes/7.3.0/) release notes for previously documented issues that may still apply.
+
+## Notes
+
+* This release includes security-related package updates.
+* The Unraid API version remains 4.34.0.
+
+## Rolling back
+
+* No special rollback notes for this release.
+
+## Changes vs. [Unraid OS 7.3.0](/unraid-os/release-notes/7.3.0/)
+
+### Security
+
+* Security: updated bind to address CVE-2026-1519, CVE-2026-3039, CVE-2026-3104, CVE-2026-3119, CVE-2026-3591, CVE-2026-3592, CVE-2026-3593, CVE-2026-5946, and CVE-2026-5947.
+* Security: updated dnsmasq to address CVE-2026-2291, CVE-2026-4890, CVE-2026-4891, CVE-2026-4892, CVE-2026-4893, and CVE-2026-5172.
+* Security: updated nginx to address CVE-2025-53859, CVE-2026-1642, CVE-2026-27651, CVE-2026-27654, CVE-2026-27784, CVE-2026-28753, CVE-2026-28755, CVE-2026-32647, CVE-2026-40460, CVE-2026-40701, CVE-2026-42934, CVE-2026-42945, and CVE-2026-42946.
+* Security: updated rsync to address CVE-2026-29518, CVE-2026-43617, CVE-2026-43618, CVE-2026-43619, CVE-2026-43620, and CVE-2026-45232.
+* Security: updated Docker to 29.5.1, including Docker upstream CVE fixes.
+* Security: updated avahi, glibc, and jq with NVD-referenced security fixes listed in the base distro updates below.
+
+### Containers / Docker
+
+* Improvement: Docker engine updated to 29.5.1.
+* Fix: the Docker container dropdown menu remains usable when many containers are shown.
+
+### Storage
+
+* Improvement: ZFS updated to 2.4.2_6.18.33_Unraid.
+* Fix: unassigned spare disks now spin down again as expected.
+* Fix: mirrored boot pools can recover from a degraded state after a member returns for cache pool usage.
+* Fix: relaxed the pool name validity check when importing existing pools to match pre-7.3 validation.
+* Fix: Replacing online raidz device can fail
+
+### WebGUI / System
+
+* Fix: restored missing Connect version-check logic so required updates are detected correctly.
+* Fix: file uploads are now handled correctly on Safari iOS.
+
+### Networking / Hardware
+
+* Fix: dhcpcd no longer waits 60 seconds to obtain an IP address.
+
+### Linux kernel
+
+* Linux kernel: update to 6.18.33-Unraid.
+
+## Base distro updates
+
+### Updated packages (25)
+
+* aaa_glibc-solibs: version 2.42 -> 2.43
+* at-spi2-core: version 2.60.3 -> 2.60.4
+* avahi: version 0.8-3_SBo_LT -> 20260508_3737842-1_SBo (NVD: CVE-2023-38469, CVE-2023-38470, CVE-2023-38471, CVE-2023-38472, CVE-2023-38473)
+* bash: version 5.3.009 -> 5.3.009-2
+* bind: version 9.20.22 -> 9.20.23 (CVE-2026-3039, CVE-2026-3592, CVE-2026-3593, CVE-2026-5946, CVE-2026-5947; NVD: CVE-2026-5950)
+* dnsmasq: version 2.92 -> 2.92rel2
+* docker: version 29.4.3-1_LT -> 29.5.1-1_LT
+* elogind: version 255.24 -> 255.25
+* fontconfig: version 2.17.1-5 -> 2.18.0-2
+* glibc: version 2.42-2_LT -> 2.43 (NVD: CVE-2025-15281, CVE-2026-0861, CVE-2026-0915)
+* jq: version 1.6-1_SBo -> 1.8.1-1_SBo (NVD: CVE-2024-53427, CVE-2025-9403)
+* less: version 692 -> 702
+* libXi: version 1.8.2 -> 1.8.3
+* libedit: version 20260508_3.1 -> 20260512_3.1
+* libusb: version 1.0.29 -> 1.0.30
+* libusb-compat: version 0.1.8 -> 0.1.9
+* lvm2: version 2.03.40 -> 2.03.41
+* mesa: version 26.1.0 -> 26.1.1
+* nginx: version 1.27.2-1_SBo_LT -> 1.30.1-1_SBo_LT (NVD: CVE-2025-53859, CVE-2026-1642, CVE-2026-27651, CVE-2026-27654, CVE-2026-27784, CVE-2026-28753, CVE-2026-28755, CVE-2026-32647, CVE-2026-40460, CVE-2026-40701, CVE-2026-42934, CVE-2026-42945, CVE-2026-42946)
+* rsync: version 3.4.2 -> 3.4.3 (CVE-2026-29518, CVE-2026-43617, CVE-2026-43618, CVE-2026-43619, CVE-2026-43620, CVE-2026-45232)
+* samba: version 4.22.8-1_LT -> 4.22.10-1_LT
+* util-linux: version 2.42-2 -> 2.42.1
+* which: version 2.23 -> 2.25
+* xev: version 1.2.6 -> 1.2.7
+* xfsprogs: version 7.0.0 -> 7.0.1
+* zfs: version 2.4.1_6.18.29_Unraid-1_LT -> 2.4.2_6.18.33_Unraid-1_LT

--- a/docs/unraid-os/release-notes/7.3.1.md
+++ b/docs/unraid-os/release-notes/7.3.1.md
@@ -1,8 +1,4 @@
-# Release notes · Unraid OS 7.3.1
-
-## Version 7.3.1-rc.0.3
-
-## Version 7.3.1 2026-05-26
+# Version 7.3.1 2026-05-26
 
 This release focuses on security updates, a Linux kernel update, Docker and ZFS updates, storage fixes, WebGUI/system fixes, and base distro package updates.
 


### PR DESCRIPTION
## Summary

Adds the Unraid OS 7.3.1 changelog page under `docs/unraid-os/release-notes/`.

The new page covers the 7.3.1 release date, upgrade guidance, known issue status, rollback notes, changes from 7.3.0, and base distro package updates.

## Impact

Users can now find the 7.3.1 security, Linux kernel, Docker, ZFS, storage, WebGUI/system, networking, hardware, and package update details in the docs site.

## Validation

- `pnpm exec remark docs/unraid-os/release-notes/7.3.1.md --quiet --frail`

Full build was not run, following this repo's validation guidance for routine docs changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added release notes for Unraid OS 7.3.1 documenting security updates, Docker engine improvements, storage/ZFS enhancements, WebGUI and Safari upload fixes, networking optimizations, kernel updates, and 25 base distro package upgrades.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unraid/docs/pull/493?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->