### PR TITLE
Update Parity Swap process description (to clarify disk replacement order)

### DIFF
--- a/docs/unraid-os/using-unraid-to/manage-storage/array/replacing-disks-in-array.mdx
+++ b/docs/unraid-os/using-unraid-to/manage-storage/array/replacing-disks-in-array.mdx
@@ -205,7 +205,7 @@ This procedure works for both data drives and %%parity drives|parity-drives%% th
 
 ## Parity swap
 
-Parity swap is a special procedure used when you need to replace a data disk with a disk that is larger than your current parity disk. The process moves your current parity disk to the data slot, then installs a new, larger disk as the new parity disk. This ensures your array remains protected and allows for larger data drives in the future.
+Parity swap is a special procedure used when you need to replace a data disk with a disk that is larger than your current parity disk. The process installs a new, larger disk as the new parity disk, then installs your previous parity disk to the data slot. This ensures your array remains protected and allows for larger data drives in the future.
 
 Use a parity swap when your replacement data drive is larger than your current parity disk. This isn't necessary if your new data drive is the same size or smaller than your parity disk.
 


### PR DESCRIPTION
Clarify the Parity Swap process description to correctly state that the new parity disk is installed first (previous wording indicated the new parity was installed as the second step).

Before Submitting This PR, Please Ensure You Have Completed The Following:

1. [ ] Are internal links to wiki documents using [relative file links](https://docusaurus.io/docs/markdown-features/links)?
2. [ ] Are all new documentation files lowercase, with dash separated names (ex. unraid-os.mdx)?
3. [ ] Are all assets (images, etc), located in an assets/ subfolder next to the .md/mdx files?
4. [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
5. [ ] Is the build succeeding?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Parity swap procedure documentation to clarify the correct sequence of operations when replacing disks in the array.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unraid/docs/pull/495?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->