### PR TITLE
[codex] Update DiskSpeed diagnostics guidance

### DIFF
--- a/docs/unraid-os/troubleshooting/diagnostics/capture-diagnostics-and-logs.mdx
+++ b/docs/unraid-os/troubleshooting/diagnostics/capture-diagnostics-and-logs.mdx
@@ -103,35 +103,24 @@ Make sure to replace `/dev/sdX` with a valid physical device. Avoid logical Unra
 
 :::
 
-### Comprehensive test (diskspeed.sh)
+### Comprehensive test (DiskSpeed)
 
-For a more detailed assessment of all attached drives, including %%parity|parity%% and data drives, consider using the community script `diskspeed.sh`.
+For a more detailed assessment of all attached drives, including %%parity|parity%% and data drives, consider using DiskSpeed.
 
-This script:
+DiskSpeed:
 
 - Tests read speeds at multiple linear offsets across the disk surface
 - Generates CSV data and performance heat maps (images)
 - Can identify zones of poor performance, which might be a sign of failing hardware or problematic SMR drives
 
-To get started with `diskspeed.sh`:
+To get started with DiskSpeed:
 
-1. Download the script from the [Unraid forums](https://forums.unraid.net/topic/31073-disk-speed-test-graphs-disk-bottlenecks-identified-see-how-fast-your-disks-can-really-go/).
-2. Place it in a persistent path like `/boot/scripts/`.
-3. Make it executable:
-
-```
-chmod +x /boot/scripts/diskspeed.sh
-```
-
-4. Run the script:
-
-```
-bash /boot/scripts/diskspeed.sh
-```
+1. Install DiskSpeed from [Community Applications](/community-applications/) (***Apps tab***) by searching for "DiskSpeed".
+2. For manual installation instructions, visit the [DiskSpeed GitHub repository](https://github.com/jbartlett777/DiskSpeed).
 
 :::note
 
-This script only performs read-only operations and won't modify any data on your drives. However, it's best to schedule the test during idle periods, as it may affect disk I/O and interfere with %%array|array%% performance.
+DiskSpeed performs read-only tests for hard drive benchmarks. SSD benchmarks may write temporary benchmark files, so review DiskSpeed's guidance before testing SSDs. Schedule benchmarks during idle periods, as they may affect disk I/O and interfere with %%array|array%% performance.
 
 :::
 

--- a/i18n/de/docusaurus-plugin-content-docs/current/unraid-os/troubleshooting/diagnostics/capture-diagnostics-and-logs.mdx
+++ b/i18n/de/docusaurus-plugin-content-docs/current/unraid-os/troubleshooting/diagnostics/capture-diagnostics-and-logs.mdx
@@ -111,35 +111,24 @@ Make sure to replace `/dev/sdX` with a valid physical device. Avoid logical Unra
 
 :::
 
-### Umfassender Test (diskspeed.sh)
+### Umfassender Test (DiskSpeed)
 
-Für eine detailliertere Bewertung aller angeschlossenen Laufwerke, einschließlich %%parity|parity%%- und Datenträger, sollten Sie das Community-Skript `diskspeed.sh` verwenden.
+Für eine detailliertere Bewertung aller angeschlossenen Laufwerke, einschließlich %%parity|parity%%- und Datenträger, sollten Sie DiskSpeed verwenden.
 
-Dieses Skript:
+DiskSpeed:
 
 - Testet Lesegeschwindigkeiten an mehreren linearen Offsets auf der Festplattenoberfläche
 - Generiert CSV-Daten und Leistungs-Heatmaps (Bilder)
 - Kann Bereiche schlechter Leistung identifizieren, was ein Zeichen für fehlerhafte Hardware oder problematische SMR-Festplatten sein könnte
 
-So beginnen Sie mit `diskspeed.sh`:
+So beginnen Sie mit DiskSpeed:
 
-1. Laden Sie das Skript von den [Unraid-Foren](https://forums.unraid.net/topic/31073-disk-speed-test-graphs-disk-bottlenecks-identified-see-how-fast-your-disks-can-really-go/) herunter.
-2. Platzieren Sie es in einem persistenten Pfad wie `/boot/scripts/`.
-3. Machen Sie es ausführbar:
-
-```
-chmod +x /boot/scripts/diskspeed.sh
-```
-
-4. Führen Sie das Skript aus:
-
-```
-bash /boot/scripts/diskspeed.sh
-```
+1. Installieren Sie DiskSpeed über [Community-Anwendungen](/community-applications/) (***Apps-Tab***) durch die Suche nach "DiskSpeed".
+2. Für manuelle Installationsanweisungen besuchen Sie das [DiskSpeed-GitHub-Repository](https://github.com/jbartlett777/DiskSpeed).
 
 :::note
 
-This script only performs read-only operations and won't modify any data on your drives. However, it's best to schedule the test during idle periods, as it may affect disk I/O and interfere with %%array|array%% performance.
+DiskSpeed führt bei Benchmarks für Festplatten nur Lesetests durch. SSD-Benchmarks können temporäre Testdateien schreiben. Lesen Sie daher die DiskSpeed-Anleitung, bevor Sie SSDs testen. Planen Sie Benchmarks während Leerlaufzeiten, da sie die Festplatten-I/O beeinflussen und die %%array|array%%-Leistung beeinträchtigen können.
 
 :::
 

--- a/i18n/es/docusaurus-plugin-content-docs/current/unraid-os/troubleshooting/diagnostics/capture-diagnostics-and-logs.mdx
+++ b/i18n/es/docusaurus-plugin-content-docs/current/unraid-os/troubleshooting/diagnostics/capture-diagnostics-and-logs.mdx
@@ -111,35 +111,24 @@ Asegúrate de reemplazar `/dev/sdX` con un dispositivo físico válido. Evita di
 
 :::
 
-### Prueba completa (diskspeed.sh)
+### Prueba completa (DiskSpeed)
 
-Para una evaluación más detallada de todos los discos conectados, incluidas unidades de %%parity|parity%% y datos, considera usar el script de la comunidad `diskspeed.sh`.
+Para una evaluación más detallada de todos los discos conectados, incluidas unidades de %%parity|parity%% y datos, considera usar DiskSpeed.
 
-Este script:
+DiskSpeed:
 
 - Prueba las velocidades de lectura en múltiples offset lineales a través de la superficie del disco
 - Genera datos CSV y mapas de calor de rendimiento (imágenes)
 - Puede identificar zonas de bajo rendimiento, que pueden ser una señal de hardware defectuoso o discos SMR problemáticos
 
-Para comenzar con `diskspeed.sh`:
+Para comenzar con DiskSpeed:
 
-1. Descarga el script desde los [foros de Unraid](https://forums.unraid.net/topic/31073-disk-speed-test-graphs-disk-bottlenecks-identified-see-how-fast-your-disks-can-really-go/).
-2. Colócalo en una ruta persistente como `/boot/scripts/`.
-3. Hazlo ejecutable:
-
-```
-chmod +x /boot/scripts/diskspeed.sh
-```
-
-4. Ejecuta el script:
-
-```
-bash /boot/scripts/diskspeed.sh
-```
+1. Instale DiskSpeed desde [Community Applications](/community-applications/) (***Pestaña de Apps***) buscando "DiskSpeed".
+2. Para instrucciones de instalación manual, visite el [repositorio de GitHub de DiskSpeed](https://github.com/jbartlett777/DiskSpeed).
 
 :::note
 
-Este script solo realiza operaciones de solo lectura y no modificará ningún dato en tus discos. Sin embargo, es mejor programar la prueba durante períodos de inactividad, ya que puede afectar el I/O del disco e interferir con el rendimiento del %%array|array%%.
+DiskSpeed realiza pruebas de solo lectura para benchmarks de discos duros. Los benchmarks de SSD pueden escribir archivos temporales de prueba, así que revise la guía de DiskSpeed antes de probar SSD. Programe los benchmarks durante períodos de inactividad, ya que pueden afectar el I/O del disco e interferir con el rendimiento del %%array|array%%.
 
 :::
 

--- a/i18n/fr/docusaurus-plugin-content-docs/current/unraid-os/troubleshooting/diagnostics/capture-diagnostics-and-logs.mdx
+++ b/i18n/fr/docusaurus-plugin-content-docs/current/unraid-os/troubleshooting/diagnostics/capture-diagnostics-and-logs.mdx
@@ -103,35 +103,24 @@ Assurez-vous de remplacer `/dev/sdX` par un appareil physique valide. Évitez le
 
 :::
 
-### Test complet (diskspeed.sh)
+### Test complet (DiskSpeed)
 
-Pour une évaluation plus détaillée de tous les disques connectés, y compris les disques de %%parity|parity%% et de données, envisagez d'utiliser le script communautaire `diskspeed.sh`.
+Pour une évaluation plus détaillée de tous les disques connectés, y compris les disques de %%parity|parity%% et de données, envisagez d'utiliser DiskSpeed.
 
-Ce script :
+DiskSpeed :
 
 - Testes les vitesses de lecture à plusieurs décalages linéaires sur la surface du disque
 - Génère des données CSV et des cartes de chaleur de performance (images)
 - Peut identifier des zones de mauvaise performance, ce qui pourrait être un signe de matériel défaillant ou de disques SMR problématiques
 
-Pour commencer avec `diskspeed.sh` :
+Pour commencer avec DiskSpeed :
 
-1. Téléchargez le script depuis les [forums Unraid](https://forums.unraid.net/topic/31073-disk-speed-test-graphs-disk-bottlenecks-identified-see-how-fast-your-disks-can-really-go/).
-2. Placez-le dans un chemin persistant comme `/boot/scripts/`.
-3. Rendez-le exécutable :
-
-```
-chmod +x /boot/scripts/diskspeed.sh
-```
-
-4. Exécutez le script :
-
-```
-bash /boot/scripts/diskspeed.sh
-```
+1. Installez DiskSpeed depuis [Community Applications](/community-applications/) (***onglet Apps***) en recherchant "DiskSpeed".
+2. Pour les instructions d'installation manuelle, consultez le [dépôt GitHub DiskSpeed](https://github.com/jbartlett777/DiskSpeed).
 
 :::note
 
-Ce script effectue uniquement des opérations en lecture seule et ne modifiera pas les données de vos disques. Cependant, il est préférable de programmer le test pendant les périodes d'inactivité, car cela peut affecter l'E/S du disque et interférer avec les performances de l'%%array|array%%.
+DiskSpeed effectue des tests en lecture seule pour les benchmarks de disques durs. Les benchmarks de SSD peuvent écrire des fichiers temporaires de test, consultez donc les instructions de DiskSpeed avant de tester des SSD. Planifiez les benchmarks pendant les périodes d'inactivité, car ils peuvent affecter l'E/S du disque et interférer avec les performances de l'%%array|array%%.
 
 :::
 

--- a/i18n/ja/docusaurus-plugin-content-docs/current/unraid-os/troubleshooting/diagnostics/capture-diagnostics-and-logs.mdx
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/unraid-os/troubleshooting/diagnostics/capture-diagnostics-and-logs.mdx
@@ -103,35 +103,24 @@ for ((i=0;i<12;i++)); do hdparm -tT /dev/sdX; done
 
 :::
 
-### 総合テスト (diskspeed.sh)
+### 総合テスト (DiskSpeed)
 
-%%parity|parity%% ドライブとデータドライブを含む、接続されているすべてのドライブをより詳細に評価するには、コミュニティスクリプト `diskspeed.sh` の使用を検討してください。
+%%parity|parity%% ドライブとデータドライブを含む、接続されているすべてのドライブをより詳細に評価するには、DiskSpeed の使用を検討してください。
 
-このスクリプトは次のことを行います:
+DiskSpeed は次のことを行います:
 
 - ディスク表面全体で複数の線形オフセットにおける読み取り速度をテストします
 - CSV データと性能ヒートマップ（画像）を生成します
 - 性能の低い領域を特定できます。これは、ハードウェアの故障や問題のある SMR ドライブの兆候である可能性があります
 
-`diskspeed.sh` を始めるには:
+DiskSpeed を始めるには:
 
-1. スクリプトを [Unraid フォーラム](https://forums.unraid.net/topic/31073-disk-speed-test-graphs-disk-bottlenecks-identified-see-how-fast-your-disks-can-really-go/) からダウンロードします。
-2. `/boot/scripts/` のような永続パスに配置します。
-3. 実行可能にします:
-
-```
-chmod +x /boot/scripts/diskspeed.sh
-```
-
-4. スクリプトを実行します:
-
-```
-bash /boot/scripts/diskspeed.sh
-```
+1. [Community Applications](/community-applications/)（***Apps tab***）で「DiskSpeed」を検索して DiskSpeed をインストールします。
+2. 手動インストール手順については、[DiskSpeed GitHub リポジトリ](https://github.com/jbartlett777/DiskSpeed) を参照してください。
 
 :::note
 
-このスクリプトは読み取り専用の操作のみを行い、ドライブ上のデータを変更しません。ただし、ディスク I/O に影響し、%%array|array%% の性能に干渉する可能性があるため、テストはアイドル時間帯に実行するのが最善です。
+DiskSpeed はハードドライブのベンチマークでは読み取り専用のテストを実行します。SSD ベンチマークでは一時的なテストファイルを書き込む場合があるため、SSD をテストする前に DiskSpeed のガイダンスを確認してください。ベンチマークはディスク I/O に影響し、%%array|array%% の性能に干渉する可能性があるため、アイドル時間帯に実行してください。
 
 :::
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/unraid-os/troubleshooting/diagnostics/capture-diagnostics-and-logs.mdx
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/unraid-os/troubleshooting/diagnostics/capture-diagnostics-and-logs.mdx
@@ -103,35 +103,24 @@ for ((i=0;i<12;i++)); do hdparm -tT /dev/sdX; done
 
 :::
 
-### 全面测试(diskspeed.sh)
+### 全面测试(DiskSpeed)
 
-要更详细地评估所有连接的驱动器，包括 %%parity|parity%% 和数据驱动器，考虑使用社区脚本 `diskspeed.sh`。
+要更详细地评估所有连接的驱动器，包括 %%parity|parity%% 和数据驱动器，考虑使用 DiskSpeed。
 
-该脚本：
+DiskSpeed：
 
 - 在磁盘表面多个线性偏移处测试读取速度
 - 生成CSV数据和性能热图（图像）
 - 可以识别出表现不佳的区域，这可能是硬件故障或问题SMR驱动器的征兆
 
-要开始使用`diskspeed.sh`：
+要开始使用 DiskSpeed：
 
-1. 从[Unraid论坛](https://forums.unraid.net/topic/31073-disk-speed-test-graphs-disk-bottlenecks-identified-see-how-fast-your-disks-can-really-go/)下载脚本。
-2. 将它放在像`/boot/scripts/`这样持久的路径中。
-3. 使其可执行：
-
-```
-chmod +x /boot/scripts/diskspeed.sh
-```
-
-4. 运行脚本：
-
-```
-bash /boot/scripts/diskspeed.sh
-```
+1. 在 [社区应用程序](/community-applications/) （***应用程序选项卡***）中搜索 "DiskSpeed" 来安装 DiskSpeed。
+2. 如需手动安装说明，请访问 [DiskSpeed GitHub 仓库](https://github.com/jbartlett777/DiskSpeed)。
 
 :::note
 
-此脚本仅执行只读操作，不会修改驱动器上的任何数据。然而，最好在空闲期间安排测试，因为它可能会影响磁盘 I/O 并干扰 %%array|array%% 性能。
+DiskSpeed 对硬盘基准测试执行只读测试。SSD 基准测试可能会写入临时测试文件，因此在测试 SSD 前请查看 DiskSpeed 的指南。请在空闲期间安排基准测试，因为它们可能会影响磁盘 I/O 并干扰 %%array|array%% 性能。
 
 :::
 


### PR DESCRIPTION
## What changed

- Replaced the dead `diskspeed.sh` Unraid forums link in the diagnostics docs.
- Updated the English diagnostics page to point users to DiskSpeed via Community Applications and the DiskSpeed GitHub repository for manual installation.
- Removed obsolete `/boot/scripts/diskspeed.sh` chmod/bash instructions from the English and localized diagnostics pages.
- Clarified that DiskSpeed hard drive benchmarks are read-only, while SSD benchmarks may write temporary benchmark files.

## Why

The old forum topic link is no longer valid, and the manual script guidance no longer matches the newer DiskSpeed package guidance already present elsewhere in the docs.

## Validation

- `rg -n "31073-disk-speed-test|forums\\.unraid\\.net/topic/31073|/boot/scripts/diskspeed\\.sh|bash /boot/scripts/diskspeed\\.sh|chmod \\+x /boot/scripts/diskspeed\\.sh" docs/unraid-os/troubleshooting/diagnostics/capture-diagnostics-and-logs.mdx i18n/*/docusaurus-plugin-content-docs/current/unraid-os/troubleshooting/diagnostics/capture-diagnostics-and-logs.mdx` returned no matches.
- `git diff --check`
- `curl -I -L --max-time 10 https://github.com/jbartlett777/DiskSpeed` returned HTTP 200.

Per repo guidance, I did not run the full build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated diagnostics troubleshooting documentation across all supported languages to recommend the DiskSpeed application for comprehensive disk testing and performance analysis.
  * Included installation guidance via Community Applications and GitHub, clarified DiskSpeed's read-only benchmark capabilities, and provided recommendations for scheduling tests during idle periods to minimize array I/O impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->