### PR TITLE
Fix ethtool path in Wake-on-LAN documentation

### DIFF
--- a/docs/unraid-os/system-administration/advanced-tools/wake-on-lan.mdx
+++ b/docs/unraid-os/system-administration/advanced-tools/wake-on-lan.mdx
@@ -87,7 +87,7 @@ The plugin manages most sleep configuration options.
   2. Add this line:
 
   ```
-  /sbin/ethtool -s eth0 wol g
+  /usr/sbin/ethtool -s eth0 wol g
   ```
   :::
 


### PR DESCRIPTION
On Unraid 7.2.4, ethtool is installed at:

/usr/sbin/ethtool

while:

/sbin/ethtool

does not exist.

As a result, the command currently documented in the Wake-on-LAN guide fails when copied directly into /boot/config/go.

This PR updates the path to match the current installation location.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Wake-on-LAN manual configuration instructions with corrected system command path for improved setup accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->