### PR TITLE
[codex] Document internal boot flash label requirement

### DIFF
--- a/docs/unraid-os/getting-started/set-up-unraid/internal-boot-faq.mdx
+++ b/docs/unraid-os/getting-started/set-up-unraid/internal-boot-faq.mdx
@@ -15,16 +15,18 @@ This page contains frequently asked questions about internal boot in Unraid OS. 
 <details>
   <summary>If you'd rather watch a step-by-step walkthrough, these videos cover both common internal boot paths.</summary>
 
-  - [Set up a new server with internal boot](https://www.youtube.com/watch?v=NMHaMaa8iV0)
-  - [Convert an existing server to internal boot](https://www.youtube.com/watch?v=sruWM1PqjVo)
+- [Set up a new server with internal boot](https://www.youtube.com/watch?v=NMHaMaa8iV0)
+- [Convert an existing server to internal boot](https://www.youtube.com/watch?v=sruWM1PqjVo)
 
-  <div style={{ marginBottom: "1.5rem" }}>
-    <p><strong>New server setup</strong></p>
-    <ResponsiveEmbed
-      src="https://www.youtube.com/embed/NMHaMaa8iV0"
-      title="Unraid 7.3 Beta: Set Up a New Server with Internal Boot"
-    />
-  </div>
+<div style={{ marginBottom: "1.5rem" }}>
+  <p>
+    <strong>New server setup</strong>
+  </p>
+  <ResponsiveEmbed
+    src="https://www.youtube.com/embed/NMHaMaa8iV0"
+    title="Unraid 7.3 Beta: Set Up a New Server with Internal Boot"
+  />
+</div>
 
   <div>
     <p><strong>Existing server conversion</strong></p>
@@ -36,6 +38,7 @@ This page contains frequently asked questions about internal boot in Unraid OS. 
 </details>
 
 ### I switched from flash boot to internal boot, but the system still boots from flash. What should I do? {/* #internal-boot-bios-order */}
+
 ### Why would I use internal boot instead of a USB flash drive? {/* #internal-boot-benefits */}
 
 Internal boot is optional. If your USB flash boot setup is reliable and fits your server, you do not need to switch just because internal boot exists.
@@ -74,6 +77,16 @@ Internal boot uses %%ZFS|zfs%%, and a mirrored setup uses a %%ZFS mirror|zfs%% f
 ### Can I enable internal boot and still license from flash? {/* #internal-boot-flash-license */}
 
 Yes. The licensing method is independent of the boot method.
+
+When you use internal boot with a separate USB flash device for licensing, the licensing USB must be discoverable by its FAT volume label. Use the default label `UNRAID` unless your boot configuration sets a matching `unraidlabel=` kernel parameter.
+
+For example, if the licensing USB is labeled `MYLABEL`, the boot configuration must include:
+
+```text
+unraidlabel=MYLABEL
+```
+
+Custom labels must use 11 characters or fewer. Use uppercase letters `A-Z`, numbers `0-9`, hyphens (`-`), or underscores (`_`).
 
 For TPM-based licensing details, see the [TPM Licensing FAQ (7.3+)](/unraid-os/troubleshooting/tpm-licensing-faq/).
 

--- a/docs/unraid-os/troubleshooting/licensing-faq.mdx
+++ b/docs/unraid-os/troubleshooting/licensing-faq.mdx
@@ -102,7 +102,7 @@ This does not apply if you have configured internal boot.
 
 Navigate to **_Tools → Registration_** in the %%WebGUI|web-gui%%. Here, you can find your current license type and registration details.
 
-For internal boot questions, see the [Internal Boot FAQ (7.3+)](../getting-started/set-up-unraid/internal-boot-faq.mdx).
+For internal boot questions, including flash licensing USB label requirements, see the [Internal Boot FAQ (7.3+)](../getting-started/set-up-unraid/internal-boot-faq.mdx#internal-boot-flash-license).
 For TPM-based licensing questions, see the [TPM Licensing FAQ (7.3+)](tpm-licensing-faq.mdx).
 
 ---


### PR DESCRIPTION
## Summary

- Document that internal boot systems using a separate flash licensing USB must keep the licensing USB discoverable by FAT volume label.
- Add the supported custom-label path using a matching `unraidlabel=` kernel parameter.
- Link the Licensing FAQ directly to the internal boot flash licensing guidance.

## Context

Linear: OS-309

## Validation

- `pnpm exec remark docs/unraid-os/getting-started/set-up-unraid/internal-boot-faq.mdx docs/unraid-os/troubleshooting/licensing-faq.mdx --quiet --frail --no-ignore`
- `pnpm exec prettier --check docs/unraid-os/getting-started/set-up-unraid/internal-boot-faq.mdx docs/unraid-os/troubleshooting/licensing-faq.mdx`
- `git diff --check -- docs/unraid-os/getting-started/set-up-unraid/internal-boot-faq.mdx docs/unraid-os/troubleshooting/licensing-faq.mdx`

Did not run the full build per repo guidance for routine docs edits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added internal boot setup walkthrough videos
  * Enhanced guidance on USB label requirements for flash licensing scenarios
  * Improved cross-references between setup and licensing documentation sections

<!-- end of auto-generated comment: release notes by coderabbit.ai -->