### PR TITLE
Chore: Remove boot backup guidance from CA docs

### DIFF
--- a/docs/community-applications.mdx
+++ b/docs/community-applications.mdx
@@ -50,12 +50,6 @@ To install the Community Applications plugin:
 
 3. Once the installation is complete, refresh the page. The screen will automatically open the **Apps** tab and introduce you to Community Applications.
 
-:::tip
-
-Before installing, consider backing up your boot device to protect your configuration. See [Secure your boot device](/unraid-os/system-administration/secure-your-server/secure-your-boot-drive/) for backup guidance.
-
-:::
-
 ---
 
 ## Managing applications


### PR DESCRIPTION
Not necessary to suggest to backup boot device prior to installing an official Unraid plugin that is effectively a required installation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed the pre-installation backup advisory from the Community Applications documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->