### PR TITLE
Clarify Tailscale reauthenticate button location in documentation

### DIFF
--- a/docs/unraid-os/system-administration/secure-your-server/tailscale.mdx
+++ b/docs/unraid-os/system-administration/secure-your-server/tailscale.mdx
@@ -39,7 +39,7 @@ The following steps are current and accurate for Unraid 7 and later:
 
 1. Review your Tailscale account settings as described above.
 2. In Unraid, search the [**Community Apps**](/community-applications/) tab for the official %%Tailscale|tailscale%% plugin and install it.
-3. Open ***Settings → Tailscale*** and click Reauthenticate. Sign in with your %%Tailscale|tailscale%% account.
+3. Open ***Settings → Tailscale → Settings***, turn on ***Advanced View*** and click Reauthenticate. Sign in with your %%Tailscale|tailscale%% account.
 4. Click **Connect** to add your Unraid server to your %%Tailnet|tailnet%%.
 5. Visit ***Settings → Management Access*** to see your %%Tailscale|tailscale%% URLs for the %%WebGUI|web-gui%%.
 6. In ***Settings → Tailscale***, find your server's %%Tailnet|tailnet%% name and IP. Use these to access SMB/NFS shares, Docker containers, and more from any device on your %%Tailnet|tailnet%%.


### PR DESCRIPTION
Updated the Tailscale settings steps for clarity and added instructions for enabling Advanced View. The Reauthenticate button is located in the Advanced View of the Settings tab of the Tailscale plugin.

Before Submitting This PR, Please Ensure You Have Completed The Following:

1. [x] Are internal links to wiki documents using [relative file links](https://docusaurus.io/docs/markdown-features/links)?
2. [x] Are all new documentation files lowercase, with dash separated names (ex. unraid-os.mdx)?
3. [x] Are all assets (images, etc), located in an assets/ subfolder next to the .md/mdx files?
4. [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
5. [x] Is the build succeeding?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Tailscale setup guide for Unraid 7+ with the current navigation path.
  * Added a step to enable **Advanced View** before reauthenticating.
  * Removed the outdated settings path from the instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->