### PR TITLE
docs(usb-creator): update boot media guidance

### DIFF
--- a/docs/unraid-os/getting-started/set-up-unraid/create-your-bootable-media.mdx
+++ b/docs/unraid-os/getting-started/set-up-unraid/create-your-bootable-media.mdx
@@ -7,13 +7,15 @@ import FlashDriveGuidance from "../../partials/flash-drive-selection-guidance.md
 
 # Create an Unraid USB drive
 
-Unraid OS runs from a boot device. For a typical installation, this device is a USB flash drive. You can prepare it with our recommended [Automated install method](./create-your-bootable-media.mdx#automated-install-method) and the [Unraid USB Creator](https://unraid.net/download), or use the [Manual installation method](./create-your-bootable-media.mdx#manual-install-method).
+Unraid OS can boot from a USB flash drive or, in Unraid 7.3 and later, from a supported internal boot device. This page explains how to create a USB drive for a new server. You can keep using the USB drive for flash boot, or use it to start the server before you select internal boot during onboarding. See the [Internal Boot FAQ (7.3+)](./internal-boot-faq.mdx) for more information.
 
-Use a high-quality USB flash drive between 4 and 32 GB with a unique %%GUID|guid%%. The %%GUID|guid%% identifies the boot device for licensing.
+For USB boot, use a high-quality USB flash drive of any size with a unique %%GUID|guid%%. The %%GUID|guid%% identifies the USB device for licensing.
 
 :::tip[Choosing reliable boot media]
 
-For typical USB installs, that means a quality USB flash drive; licensing depends on a unique %%GUID|guid%% on the boot device. See [Choosing a boot device](#choosing-a-usb-flash-drive) in the manual install section for brand guidance and how to avoid counterfeits.
+For USB boot, choose a quality USB flash drive with a unique %%GUID|guid%%. See [Choosing a boot device](#choosing-a-usb-flash-drive) in the manual install section for guidance about reliable media and counterfeit drives.
+
+If you plan to use internal boot, you still need this USB drive to start a new server. After the first boot, the onboarding wizard lets you choose flash boot or internal boot.
 
 :::
 
@@ -35,7 +37,7 @@ Download and install the USB Creator for your computer:
 - [macOS](https://releases.unraid.net/dl/stable/usb-creator.dmg)
 - [Linux](https://releases.unraid.net/dl/stable/usb-creator.appimage)
 
-Insert the USB flash drive into your computer. Close any application that has the drive open.
+Insert the USB drive into your computer. Close any application that has the drive open.
 
 ### Select the language
 
@@ -121,8 +123,14 @@ UEFI systems can boot from the drive without any extra step. For an older BIOS-o
 1. Insert the prepared USB drive into the server.
 2. Open the server's BIOS or UEFI settings.
 3. Set the USB drive as the first boot device.
-4. Enable %%hardware virtualization|hvm%% features, including %%IOMMU|iommu%%. See [HVM & IOMMU configuration](../../using-unraid-to/create-virtual-machines/overview-and-system-prep.mdx#hvm--iommu-what-they-enable) for details.
-5. Save the BIOS settings and restart the server.
+4. Save the BIOS settings and restart the server.
+
+On Unraid 7.3 and later, when Unraid starts for the first time, the onboarding wizard lets you choose the boot method:
+
+- **Flash boot** keeps Unraid on the USB drive.
+- **Internal boot** moves Unraid to one supported internal boot device or two mirrored internal boot devices.
+
+For internal boot details, see the [Onboarding](./deploy-and-configure-unraid-os.mdx#onboarding) section and the [Internal Boot FAQ (7.3+)](./internal-boot-faq.mdx).
 
 After Unraid OS starts, continue with [Deploy and configure Unraid OS](./deploy-and-configure-unraid-os.mdx).
 
@@ -144,15 +152,15 @@ The Unraid USB Creator only lists USB storage devices for this workflow. Make su
 3. For a BIOS-only system, run the platform-specific `make_bootable` script described in [Finish the USB setup](#finish-the-usb-setup).
 4. Save the settings and restart the server.
 
-If the server still does not boot, use the [Manual install method](#manual-install-method) to prepare the drive again.
+If you chose internal boot and the server does not boot after onboarding, move the selected internal boot device to the top of the BIOS/UEFI boot order. If the server still does not boot, use the [Manual install method](#manual-install-method) to prepare the USB drive again.
 
 ### The USB drive cannot register a license
 
-Unraid licensing requires a unique %%GUID|guid%%. If the drive has no unique %%GUID|guid%%, use a different USB flash drive. See [Choosing a boot device](#choosing-a-usb-flash-drive) for drive selection guidance.
+USB boot and USB licensing require a unique %%GUID|guid%%. If the drive has no unique %%GUID|guid%%, use a different USB flash drive. If you use internal boot with TPM-based licensing, see the [Internal Boot FAQ (7.3+)](./internal-boot-faq.mdx#internal-boot-flash-license).
 
 ## Manual install method {/* #manual-install-method */}
 
-The manual installation method is designed for situations where the USB Flash Creator tool is either unavailable or incompatible with your hardware. This approach provides complete control over the formatting and setup process, making it ideal for advanced users or for troubleshooting specific issues with a USB device.
+The manual installation method is for situations where the USB Creator is unavailable or incompatible with your hardware. This method gives you control over the formatting and setup process.
 
 ### Choosing a boot device {/* #choosing-a-usb-flash-drive */}
 
@@ -166,7 +174,7 @@ The manual installation method is designed for situations where the USB Flash Cr
 
 :::important
 
-On Windows, drives larger than 32 GB cannot be formatted as FAT32 using the built-in formatting tools (they default to exFAT). For drives larger than 32 GB, you'll need to use a third-party tool like [Rufus](https://rufus.ie/en/) to format as FAT32.
+On Windows, the built-in formatting tools cannot format drives larger than 32 GB as FAT32. They default to exFAT. For a larger drive, use a FAT32-capable tool such as [Rufus](https://rufus.ie/en/).
 
 :::
 


### PR DESCRIPTION
## Summary
This follow-up to #524 updates the screenshot-led guide for creating a new Unraid USB boot device with the USB Creator.

## Why This Exists
The page previously provided only a high-level six-step outline and included stale USB-only guidance. Users needed current boot-device choices, a clear warning about erasing the selected drive, and guidance for first boot and older BIOS-only systems.

## Resolution
Expand the existing Create an Unraid USB drive page with the five merged USB Creator screenshots, step-by-step UI actions, optional server/network customization notes, current flash-versus-internal-boot guidance for Unraid 7.3+, UEFI/legacy BIOS instructions, and troubleshooting.

## Reviewer Considerations
- Confirm the stable-release guidance and the optional development-image warning match the intended USB Creator experience.
- Check the platform-specific legacy BIOS script names and first-boot guidance.
- Confirm that internal boot is described as an onboarding choice after the initial USB boot.
- Confirm that the USB Creator guidance does not impose a drive-capacity range; the remaining 32 GB reference applies only to Windows FAT32 formatting for manual installs.
- The manual installation section remains in place; this change improves the recommended automated path rather than replacing it.
- Screenshot references target the assets merged in `origin/main` by #523.

## Behavior Changes
Documentation-only. Users now see a complete path from USB Creator download through first boot, with flash boot or internal boot choices, troubleshooting for missing drives and boot failures, and GUID licensing guidance.

## Implementation Summary
- Renamed the page label/title to Create an Unraid USB drive.
- Expanded the automated install section with five screenshot-linked workflow steps.
- Documented optional Server name, Wi-Fi, and Network customization.
- Removed the outdated 4–32 GB recommendation and separated the Windows FAT32 formatting limit from USB Creator capacity guidance.
- Added the Unraid 7.3+ internal boot path and removed unrelated virtualization/IOMMU setup from the USB creation procedure.
- Added UEFI versus BIOS-only boot guidance and troubleshooting.

## Verification
- `./node_modules/.bin/remark docs/unraid-os/getting-started/set-up-unraid/create-your-bootable-media.mdx --quiet --frail`
- `./node_modules/.bin/prettier --check docs/unraid-os/getting-started/set-up-unraid/create-your-bootable-media.mdx`
- `git diff --check`
- Verified all five screenshot paths resolve against `origin/main`.
- Full Docusaurus build not run because repository guidance discourages it for routine docs edits.

## Risk
Low. Documentation-only change; the page links to existing screenshot assets and leaves the manual install instructions intact.
