### PR TITLE
docs: add mover progress enablement workaround

### DIFF
--- a/docs/unraid-os/release-notes/7.4.0.md
+++ b/docs/unraid-os/release-notes/7.4.0.md
@@ -4,7 +4,7 @@ Unraid OS 7.4.0-beta.2 adds Docker multi-network and memory controls, shared bac
 
 ## Fixes / Features From 7.4.0-beta.1
 
-* New: Mover progress and status tracking is now available.
+* New: Mover progress and status tracking is now available. Due to a known issue, go to ***Settings → Scheduler → Mover Settings***, set **Mover Progress** to **Disabled**, and select **Apply**. Then set **Mover Progress** to **Enabled** and select **Apply** again.
 * Fix: Power Options retains both the Power Mode and Power Button tabs when the Dynamix System Buttons plugin is installed.
 * Fix: Power Options no longer shows the virtualization warning on bare-metal servers.
 
@@ -35,7 +35,7 @@ For step-by-step instructions, see [Updating Unraid](/unraid-os/updating-unraid/
 
 ### Storage
 
-* New: Mover progress and status tracking is now available.
+* New: Mover progress and status tracking is now available. Due to a known issue, go to ***Settings → Scheduler → Mover Settings***, set **Mover Progress** to **Disabled**, and select **Apply**. Then set **Mover Progress** to **Enabled** and select **Apply** again.
 * New: Drive-location support can use SGPIO/IBPI-capable controllers when SES is unavailable.
 * Fix: A stopped array now shows offline and filesystem status text instead of 100% utilization.
 * Fix: Pressing Enter in encrypted array passphrase fields now starts the array when passphrase validation succeeds.


### PR DESCRIPTION
## Summary

- document the 7.4.0-beta.2 Mover Progress enablement workaround
- format the navigation path using the Unraid documentation convention
- update both occurrences of the mover progress release-note entry

## Validation

- confirmed both duplicate release-note entries use identical guidance
- confirmed the path is formatted as ***Settings → Scheduler → Mover Settings***

Related: [OS-866](https://linear.app/lime-technology/issue/OS-866/740-beta2-mover-progress-uses-enableddisabled-instead-of-emhttpd-yesno)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the Unraid OS 7.4.0-beta.2 release notes with troubleshooting guidance for Mover progress tracking.
  - If Mover progress tracking behaves unexpectedly, users can toggle **Mover Progress** off and on under **Settings → Scheduler → Mover Settings**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->